### PR TITLE
Add global stylesheet and basic responsive layout

### DIFF
--- a/Index.HTML
+++ b/Index.HTML
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ToolTime Pro - The Complete Platform for Service Businesses</title>
+    <link rel="stylesheet" href="css/styles.css">
     <style>
         * {
             margin: 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,24 @@
+/* Reset */
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0;}
+body{font-family:'Arial',sans-serif;line-height:1.6;color:#333;}
+.container{max-width:1200px;margin:0 auto;padding:0 20px;}
+
+/* Header */
+header{background:linear-gradient(135deg,#1a365d 0%,#2d5c8a 100%);color:#fff;padding:1rem 0;position:fixed;width:100%;top:0;z-index:1000;}
+header .logo{font-size:1.8rem;font-weight:bold;background:linear-gradient(45deg,#4fd1c7,#81e6d9);-webkit-background-clip:text;-webkit-text-fill-color:transparent;}
+.nav-links{display:flex;list-style:none;gap:2rem;}
+.nav-links a{color:#fff;text-decoration:none;transition:color .3s;}
+.nav-links a:hover{color:#4fd1c7;}
+
+/* Tile */
+.tile{background:#fff;border-radius:8px;box-shadow:0 4px 8px rgba(0,0,0,.05);padding:1.5rem;}
+
+/* Buttons */
+.btn{display:inline-block;background:linear-gradient(45deg,#f56565,#ed8936);color:#fff;padding:12px 24px;border:none;border-radius:8px;font-weight:bold;text-decoration:none;cursor:pointer;transition:transform .3s,box-shadow .3s;}
+.btn:hover{transform:translateY(-2px);box-shadow:0 10px 25px rgba(245,101,101,.3);}
+
+/* Responsive */
+@media (max-width:768px){
+  .nav-links{flex-direction:column;gap:1rem;}
+  .container{padding:0 1rem;}
+}


### PR DESCRIPTION
## Summary
- add lightweight global stylesheet with reset rules and responsive layout helpers
- include header, tile, and button styling utilities
- link Index.HTML to use the shared stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a014f1b2488326ac659e63837806c8