### PR TITLE
Add rental pricing tool with mock data

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,69 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.card {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  width: 100%;
+  max-width: 600px;
+  margin-top: 20px;
+}
+h1 {
+  text-align: center;
+  margin-bottom: 20px;
+}
+.input-group {
+  margin-bottom: 15px;
+}
+label {
+  display: block;
+  margin-bottom: 5px;
+}
+input {
+  width: 100%;
+  padding: 8px;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.row {
+  display: flex;
+  gap: 10px;
+}
+.row .input-group {
+  flex: 1;
+}
+button {
+  width: 100%;
+  padding: 10px;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+button:hover {
+  background: #0056b3;
+}
+.result-range h2,
+.comps h2 {
+  margin-top: 0;
+}
+.comp-card {
+  background: #e9ecef;
+  padding: 10px;
+  border-radius: 6px;
+  margin-top: 10px;
+}
+.hidden {
+  display: none;
+}

--- a/tools/rental-pricing/index.html
+++ b/tools/rental-pricing/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Rental Pricing Tool</title>
+  <link rel="stylesheet" href="../../css/styles.css" />
+</head>
+<body>
+  <div class="card">
+    <h1>Rental Pricing Tool</h1>
+    <div class="input-group">
+      <label for="address">Address</label>
+      <input type="text" id="address" placeholder="123 Main St" />
+    </div>
+    <div class="row">
+      <div class="input-group">
+        <label for="beds">Beds</label>
+        <input type="number" id="beds" min="0" placeholder="3" />
+      </div>
+      <div class="input-group">
+        <label for="baths">Baths</label>
+        <input type="number" id="baths" min="0" placeholder="2" />
+      </div>
+      <div class="input-group">
+        <label for="sqft">Sqft</label>
+        <input type="number" id="sqft" min="0" placeholder="1500" />
+      </div>
+    </div>
+    <button id="estimate">Estimate Rent</button>
+  </div>
+
+  <div id="results" class="card hidden">
+    <div id="rentRange" class="result-range"></div>
+    <div id="comps" class="comps"></div>
+  </div>
+
+  <script>
+    document.getElementById('estimate').addEventListener('click', function () {
+      document.getElementById('rentRange').innerHTML = '<h2>Estimated Rent Range</h2><p>$1,800 - $2,200</p>';
+      const comps = [
+        { address: '456 Elm St', rent: '$1,950', sqft: 1400 },
+        { address: '789 Oak Ave', rent: '$2,100', sqft: 1600 },
+        { address: '101 Pine Rd', rent: '$1,875', sqft: 1350 },
+      ];
+      const compsHTML =
+        '<h2>Comparable Rentals</h2>' +
+        comps
+          .map(
+            (c) =>
+              '<div class="comp-card"><strong>' +
+              c.address +
+              '</strong><br>Rent: ' +
+              c.rent +
+              ' • ' +
+              c.sqft +
+              ' sqft</div>'
+          )
+          .join('');
+      document.getElementById('comps').innerHTML = compsHTML;
+      document.getElementById('results').classList.remove('hidden');
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add rental pricing tool with fields for address, beds, baths, and sqft
- display mock rent range and comparable rentals
- introduce shared stylesheet for card layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a014ebb0d08326a8d2873bd0541652