### PR TITLE
Add listing generator tool with mock description

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,50 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f0f0f0;
+  padding: 20px;
+}
+
+.container {
+  max-width: 600px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+label {
+  display: block;
+  margin-top: 10px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 8px;
+  margin-top: 4px;
+  box-sizing: border-box;
+}
+
+button {
+  margin-top: 15px;
+  padding: 10px 15px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+#result {
+  margin-top: 20px;
+  padding: 15px;
+  background-color: #e6f7ff;
+  border: 1px solid #b3e5fc;
+  border-radius: 4px;
+}

--- a/tools/listing-generator/index.html
+++ b/tools/listing-generator/index.html
@@ -3,74 +3,62 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Property Listing Form</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <title>Listing Generator</title>
+  <link rel="stylesheet" href="../../css/styles.css" />
 </head>
-<body class="bg-gray-100 p-6">
-  <div class="max-w-xl mx-auto bg-white p-8 rounded shadow">
-    <h1 class="text-2xl font-bold mb-4">Property Listing Form</h1>
-    <form id="listingForm" class="space-y-4">
-      <div>
-        <label for="propertyType" class="block text-sm font-medium text-gray-700">Property Type</label>
-        <select id="propertyType" name="propertyType" class="mt-1 block w-full border-gray-300 rounded">
-          <option value="apartment">Apartment</option>
-          <option value="duplex">Duplex</option>
-          <option value="commercial">Commercial</option>
-          <option value="single_family">Single Family</option>
-          <option value="other">Other</option>
-        </select>
-      </div>
-      <div class="flex space-x-4">
-        <div class="w-1/2">
-          <label for="beds" class="block text-sm font-medium text-gray-700">Beds</label>
-          <input type="number" id="beds" name="beds" class="mt-1 block w-full border-gray-300 rounded" min="0" />
-        </div>
-        <div class="w-1/2">
-          <label for="baths" class="block text-sm font-medium text-gray-700">Baths</label>
-          <input type="number" id="baths" name="baths" class="mt-1 block w-full border-gray-300 rounded" min="0" />
-        </div>
-      </div>
-      <div>
-        <label for="sqft" class="block text-sm font-medium text-gray-700">Square Footage</label>
-        <input type="number" id="sqft" name="sqft" class="mt-1 block w-full border-gray-300 rounded" min="0" />
-      </div>
-      <div>
-        <label for="details" class="block text-sm font-medium text-gray-700">Neighborhood & Features</label>
-        <textarea id="details" name="details" class="mt-1 block w-full border-gray-300 rounded" rows="4" placeholder="Describe the neighborhood and notable features"></textarea>
-      </div>
-      <button type="submit" class="w-full bg-blue-600 text-white py-2 px-4 rounded">Submit</button>
+<body>
+  <div class="container">
+    <h1>Listing Generator</h1>
+    <form id="listingForm">
+      <label for="propertyType">Property Type</label>
+      <select id="propertyType" name="propertyType">
+        <option value="House">House</option>
+        <option value="Apartment">Apartment</option>
+        <option value="Condo">Condo</option>
+        <option value="Townhome">Townhome</option>
+      </select>
+
+      <label for="beds">Bed</label>
+      <input type="number" id="beds" name="beds" min="0" />
+
+      <label for="baths">Bath</label>
+      <input type="number" id="baths" name="baths" min="0" />
+
+      <label for="sqft">Sqft</label>
+      <input type="number" id="sqft" name="sqft" min="0" />
+
+      <label for="neighborhood">Neighborhood</label>
+      <input type="text" id="neighborhood" name="neighborhood" />
+
+      <label for="features">Features</label>
+      <textarea id="features" name="features" rows="4"></textarea>
+
+      <button type="submit">Generate Listing</button>
     </form>
+    <div id="result"></div>
   </div>
 
   <script>
-    document.getElementById('listingForm').addEventListener('submit', async (e) => {
+    function callOpenAIorZapier(data) {
+      // TODO: integrate with OpenAI or Zapier
+      console.log('Placeholder call with data:', data);
+    }
+
+    document.getElementById('listingForm').addEventListener('submit', function (e) {
       e.preventDefault();
       const data = {
         propertyType: document.getElementById('propertyType').value,
         beds: document.getElementById('beds').value,
         baths: document.getElementById('baths').value,
         sqft: document.getElementById('sqft').value,
-        details: document.getElementById('details').value,
+        neighborhood: document.getElementById('neighborhood').value,
+        features: document.getElementById('features').value,
       };
 
-      try {
-        const response = await fetch('Paste your OpenAI API URL here', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(data),
-        });
-        if (response.ok) {
-          alert('Listing submitted successfully!');
-          e.target.reset();
-        } else {
-          alert('Failed to submit listing.');
-        }
-      } catch (error) {
-        console.error('Error:', error);
-        alert('An error occurred.');
-      }
+      const description = `Beautiful ${data.beds}-bed, ${data.baths}-bath ${data.propertyType} with ${data.sqft} sqft located in ${data.neighborhood}. Features include: ${data.features}.`;
+      document.getElementById('result').textContent = description;
+
+      callOpenAIorZapier(data);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- build listing generator form to capture property type, beds, baths, sqft, neighborhood, and features
- display generated description and stub function for API integration
- add shared stylesheet for layout and form styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a014e61c34832683f7167e16d9bdb1