### PR TITLE
chore: add React plugin dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chart.js": "^4.4.1"
   },
   "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
     "vite": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `@vitejs/plugin-react` to dev dependencies so Vite config can load React plugin

## Testing
- `npm i -D @vitejs/plugin-react` *(fails: 403 Forbidden/connection issues)*
- `npm run build` *(fails: vite not found without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a02b4227b88326b7ed59c018d27329