### PR TITLE
feat: add property valuation plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "description": "REtotalAI modular real estate tools site",
   "main": "index.html",
+  "type": "module",
   "scripts": {
     "start": "serve .",
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node tests/propertyValuation.test.mjs"
   },
   "keywords": [],
   "author": "REtotalAI Team",

--- a/plugins/propertyValuation.js
+++ b/plugins/propertyValuation.js
@@ -1,0 +1,9 @@
+export async function getPropertyValuation({ address, city, state, zipcode, propertyType }) {
+  const params = new URLSearchParams({ address, city, state, zipcode, propertyType });
+  const url = `https://api.externalpropertyvaluation.com/estimate?${params.toString()}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch property valuation');
+  }
+  return response.json();
+}

--- a/tests/propertyValuation.test.mjs
+++ b/tests/propertyValuation.test.mjs
@@ -1,0 +1,46 @@
+import assert from 'assert/strict';
+import { getPropertyValuation } from '../plugins/propertyValuation.js';
+
+async function testSuccess() {
+  const expected = {
+    propertyValue: 500000,
+    confidenceScore: 87,
+    lastUpdated: '2024-05-01T00:00:00Z'
+  };
+  global.fetch = async (url) => ({
+    ok: true,
+    json: async () => expected,
+  });
+  const result = await getPropertyValuation({
+    address: '123 Main St',
+    city: 'Anytown',
+    state: 'CA',
+    zipcode: '90210',
+    propertyType: 'Single Family'
+  });
+  assert.deepEqual(result, expected);
+  console.log('testSuccess passed');
+}
+
+async function testFailure() {
+  global.fetch = async () => ({ ok: false, status: 500 });
+  let threw = false;
+  try {
+    await getPropertyValuation({
+      address: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zipcode: '90210',
+      propertyType: 'Single Family'
+    });
+  } catch (err) {
+    threw = true;
+    assert.ok(err instanceof Error);
+  }
+  assert.ok(threw, 'Expected error to be thrown');
+  console.log('testFailure passed');
+}
+
+await testSuccess();
+await testFailure();
+console.log('All tests passed');

--- a/tools/deal-analyzer/index.html
+++ b/tools/deal-analyzer/index.html
@@ -88,6 +88,40 @@
 <body>
   <div class="container">
     <h1>Deal Analyzer</h1>
+    <div id="valuationPlugin">
+      <h2>Real-Time Property Valuation</h2>
+      <div class="input-group">
+        <label for="address">Address</label>
+        <input type="text" id="address" placeholder="123 Main St" />
+      </div>
+      <div class="input-group">
+        <label for="city">City</label>
+        <input type="text" id="city" placeholder="Anytown" />
+      </div>
+      <div class="input-group">
+        <label for="state">State</label>
+        <input type="text" id="state" placeholder="CA" />
+      </div>
+      <div class="input-group">
+        <label for="zipcode">ZIP Code</label>
+        <input type="text" id="zipcode" placeholder="90210" />
+      </div>
+      <div class="input-group">
+        <label for="ptype">Property Type</label>
+        <select id="ptype">
+          <option>Single Family</option>
+          <option>Multi-Family</option>
+          <option>Condo</option>
+          <option>Townhouse</option>
+        </select>
+      </div>
+      <button id="getValuation">Get Valuation</button>
+      <div id="valuationOutput" class="result-box" style="display:none; margin-top:10px;">
+        <p>Estimated Value: <span id="valuationValue"></span></p>
+        <p>Confidence: <span id="valuationConfidence"></span></p>
+        <p>Last Updated: <span id="valuationUpdated"></span></p>
+      </div>
+    </div>
     <div class="input-group">
       <label for="purchase">Purchase Price</label>
       <input type="number" id="purchase" placeholder="e.g. 150000" />
@@ -121,7 +155,31 @@
     </div>
   </div>
 
-  <script>
+  <script type="module">
+    import { getPropertyValuation } from '../../plugins/propertyValuation.js';
+
+    document.getElementById('getValuation').addEventListener('click', async () => {
+      const data = {
+        address: document.getElementById('address').value,
+        city: document.getElementById('city').value,
+        state: document.getElementById('state').value,
+        zipcode: document.getElementById('zipcode').value,
+        propertyType: document.getElementById('ptype').value,
+      };
+      try {
+        const result = await getPropertyValuation(data);
+        document.getElementById('valuationValue').textContent = '$' + result.propertyValue.toLocaleString();
+        document.getElementById('valuationConfidence').textContent = result.confidenceScore + '%';
+        document.getElementById('valuationUpdated').textContent = new Date(result.lastUpdated).toLocaleString();
+        document.getElementById('valuationOutput').style.display = 'block';
+      } catch (err) {
+        document.getElementById('valuationValue').textContent = 'Error';
+        document.getElementById('valuationConfidence').textContent = '-';
+        document.getElementById('valuationUpdated').textContent = '-';
+        document.getElementById('valuationOutput').style.display = 'block';
+      }
+    });
+
     document.getElementById('analyze').addEventListener('click', function() {
       const purchase = parseFloat(document.getElementById('purchase').value) || 0;
       const rent = parseFloat(document.getElementById('rent').value) || 0;


### PR DESCRIPTION
## Summary
- add plugin to fetch real-time property valuations via external API
- expose valuation UI on deal analyzer page and display estimates
- include node-based tests and update build workflow

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a1462e45e48326b9962828caca507b