### PR TITLE
feat: add dedicated auth pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
                 <a href="#demo" class="nav-link">Demo</a>
                 <a href="#pricing" class="nav-link">Pricing</a>
                 <a href="#about" class="nav-link">About</a>
-                <a href="#authModal" data-open-login class="btn btn-outline" aria-label="Log in">Log In</a>
-                <a href="#authModal" data-open-auth class="btn btn-primary">Start Free Trial</a>
+                <a href="login.html" class="btn btn-outline" aria-label="Log in">Log In</a>
+                <a href="signup.html" class="btn btn-primary">Start Free Trial</a>
             </div>
             <button class="mobile-menu-btn" aria-label="Toggle navigation menu" aria-expanded="false">
                 <div class="hamburger">
@@ -40,7 +40,7 @@
                 Revolutionary intelligence tools that solve every challenge in modern real estate
             </p>
             <div class="hero-cta fade-in-up" style="animation-delay: 0.2s;">
-                <a href="#authModal" data-open-auth class="btn btn-white">Start Free Trial</a>
+                <a href="signup.html" class="btn btn-white">Start Free Trial</a>
                 <a href="#tools" class="btn btn-ghost">Explore Tools</a>
             </div>
         </div>
@@ -90,7 +90,7 @@
                     <li>Market comparison engine</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
@@ -108,7 +108,7 @@
                     <li>Competition tracking</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
@@ -126,7 +126,7 @@
                     <li>Follow-up scheduler</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-new">New</span>
                 </div>
             </div>
@@ -144,7 +144,7 @@
                     <li>Predictive scoring</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
@@ -162,7 +162,7 @@
                     <li>Permit checklists</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-beta">Beta</span>
                 </div>
             </div>
@@ -180,7 +180,7 @@
                     <li>Commute analysis</li>
                 </ul>
                 <div class="tool-footer">
-                    <a href="#authModal" data-open-auth class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
@@ -278,7 +278,7 @@
                     <li>Basic market data</li>
                     <li>Email support</li>
                 </ul>
-                <a href="#authModal" data-open-auth class="btn btn-outline btn-large" style="text-decoration: none; display: inline-block; text-align: center;">Start Free</a>
+                <a href="signup.html" class="btn btn-outline btn-large" style="text-decoration: none; display: inline-block; text-align: center;">Start Free</a>
             </div>
 
             <div class="pricing-card featured">
@@ -292,7 +292,7 @@
                     <li>API access</li>
                     <li>White-label options</li>
                 </ul>
-                <a href="#authModal" data-open-auth class="btn btn-primary btn-large" style="text-decoration: none; display: inline-block; text-align: center;">Start 14-Day Trial</a>
+                <a href="signup.html" class="btn btn-primary btn-large" style="text-decoration: none; display: inline-block; text-align: center;">Start 14-Day Trial</a>
             </div>
 
             <div class="pricing-card">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Log In - REtotalAI</title>
+    <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+    <div style="max-width: 500px; margin: 5% auto; background: white; border-radius: 1rem; padding: 2.5rem; border: 1px solid var(--border);">
+        <h2 style="color: var(--primary); margin-bottom: 1rem; font-family: Georgia, serif;">Welcome Back</h2>
+        <p style="color: var(--gray); margin-bottom: 2rem;">Log in to access your real estate tools</p>
+
+        <div style="margin-bottom: 1rem;">
+            <label style="display: block; margin-bottom: 0.5rem; color: var(--dark); font-weight: 600;">Email</label>
+            <input type="email" id="loginEmail" placeholder="john@example.com" style="width: 100%; padding: 0.75rem; border: 2px solid var(--border); border-radius: 0.5rem;">
+        </div>
+
+        <div style="margin-bottom: 1.5rem;">
+            <label style="display: block; margin-bottom: 0.5rem; color: var(--dark); font-weight: 600;">Password</label>
+            <input type="password" id="loginPassword" placeholder="••••••••" style="width: 100%; padding: 0.75rem; border: 2px solid var(--border); border-radius: 0.5rem;">
+        </div>
+
+        <button onclick="handleLogin()" style="width: 100%; background: var(--accent); color: white; padding: 0.875rem; border-radius: 0.5rem; font-weight: 600; border: none; cursor: pointer; font-size: 1rem;">
+            Log In
+        </button>
+
+        <p style="text-align: center; margin-top: 1.5rem; color: var(--gray);">
+            Don't have an account?
+            <a href="signup.html" style="color: var(--accent); text-decoration: none; font-weight: 600;">Sign Up Free</a>
+        </p>
+    </div>
+    <script src="scripts/main.js"></script>
+</body>
+</html>
+

--- a/signup.html
+++ b/signup.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sign Up - REtotalAI</title>
+    <link rel="stylesheet" href="styles/main.css">
+</head>
+<body>
+    <div style="max-width: 500px; margin: 5% auto; background: white; border-radius: 1rem; padding: 2.5rem; border: 1px solid var(--border);">
+        <h2 style="color: var(--primary); margin-bottom: 1rem; font-family: Georgia, serif;">Start Your Free Trial</h2>
+        <p style="color: var(--gray); margin-bottom: 2rem;">Get instant access to professional real estate tools</p>
+
+        <div style="margin-bottom: 1rem;">
+            <label style="display: block; margin-bottom: 0.5rem; color: var(--dark); font-weight: 600;">Full Name</label>
+            <input type="text" id="signupName" placeholder="John Smith" style="width: 100%; padding: 0.75rem; border: 2px solid var(--border); border-radius: 0.5rem;">
+        </div>
+
+        <div style="margin-bottom: 1rem;">
+            <label style="display: block; margin-bottom: 0.5rem; color: var(--dark); font-weight: 600;">Email</label>
+            <input type="email" id="signupEmail" placeholder="john@example.com" style="width: 100%; padding: 0.75rem; border: 2px solid var(--border); border-radius: 0.5rem;">
+        </div>
+
+        <div style="margin-bottom: 1.5rem;">
+            <label style="display: block; margin-bottom: 0.5rem; color: var(--dark); font-weight: 600;">Password</label>
+            <input type="password" id="signupPassword" placeholder="••••••••" style="width: 100%; padding: 0.75rem; border: 2px solid var(--border); border-radius: 0.5rem;">
+        </div>
+
+        <button onclick="handleSignup()" style="width: 100%; background: var(--accent); color: white; padding: 0.875rem; border-radius: 0.5rem; font-weight: 600; border: none; cursor: pointer; font-size: 1rem;">
+            Start Free Trial
+        </button>
+
+        <p style="text-align: center; margin-top: 1.5rem; color: var(--gray);">
+            Already have an account?
+            <a href="login.html" style="color: var(--accent); text-decoration: none; font-weight: 600;">Log In</a>
+        </p>
+
+        <div style="margin-top: 1.5rem; padding-top: 1.5rem; border-top: 1px solid var(--border);">
+            <p style="text-align: center; color: var(--gray); font-size: 0.875rem;">
+                ✓ 14-day free trial &nbsp;&nbsp; ✓ No credit card required &nbsp;&nbsp; ✓ Cancel anytime
+            </p>
+        </div>
+    </div>
+    <script src="scripts/main.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- link navigation and CTAs to new signup and login pages
- add standalone signup and login pages with forms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a167e641748326a2627bd41acfca9a