### PR TITLE
Add property details lookup and auto populate fields

### DIFF
--- a/plugins/propertyValuation.js
+++ b/plugins/propertyValuation.js
@@ -7,3 +7,13 @@ export async function getPropertyValuation({ address, city, state, zipcode, prop
   }
   return response.json();
 }
+
+export async function getPropertyDetails({ address, city, state, zipcode }) {
+  const params = new URLSearchParams({ address, city, state, zipcode });
+  const url = `https://api.externalpropertyvaluation.com/details?${params.toString()}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch property details');
+  }
+  return response.json();
+}

--- a/tests/propertyValuation.test.mjs
+++ b/tests/propertyValuation.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'assert/strict';
-import { getPropertyValuation } from '../plugins/propertyValuation.js';
+import { getPropertyValuation, getPropertyDetails } from '../plugins/propertyValuation.js';
 
 async function testSuccess() {
   const expected = {
@@ -43,4 +43,22 @@ async function testFailure() {
 
 await testSuccess();
 await testFailure();
+async function testDetailsPopulate() {
+  const expected = { yearBuilt: 1995, sqft: 2000 };
+  global.fetch = async () => ({ ok: true, json: async () => expected });
+  const elements = {
+    address: { value: '123 Main St' },
+    yearBuilt: { value: '' },
+    sqft: { value: '' }
+  };
+  global.document = { getElementById: id => elements[id] };
+  const details = await getPropertyDetails({ address: elements.address.value, city: '', state: '', zipcode: '' });
+  document.getElementById('yearBuilt').value = details.yearBuilt;
+  document.getElementById('sqft').value = details.sqft;
+  assert.equal(elements.yearBuilt.value, expected.yearBuilt);
+  assert.equal(elements.sqft.value, expected.sqft);
+  console.log('testDetailsPopulate passed');
+}
+
+await testDetailsPopulate();
 console.log('All tests passed');

--- a/tools/deal-analyzer/index.html
+++ b/tools/deal-analyzer/index.html
@@ -996,7 +996,7 @@
         // Share results
         function shareResults() {
             const text = `Check out this deal:\nROI: ${document.getElementById('annualROI').textContent}\nCash Flow: ${document.getElementById('monthlyCashFlow').textContent}`;
-            
+
             if (navigator.share) {
                 navigator.share({
                     title: 'Real Estate Deal Analysis',
@@ -1008,6 +1008,22 @@
                 alert('Results copied to clipboard!');
             }
         }
+
+        async function fetchAndPopulatePropertyDetails() {
+            const addressValue = document.getElementById('address').value;
+            try {
+                const { getPropertyDetails } = await import('../../plugins/propertyValuation.js');
+                const details = await getPropertyDetails({ address: addressValue, city: '', state: '', zipcode: '' });
+                document.getElementById('yearBuilt').value = details.yearBuilt || '';
+                document.getElementById('sqft').value = details.sqft || '';
+            } catch (err) {
+                console.error('Property details lookup failed', err);
+                document.getElementById('yearBuilt').value = '';
+                document.getElementById('sqft').value = '';
+            }
+        }
+
+        document.getElementById('address').addEventListener('blur', fetchAndPopulatePropertyDetails);
 
         // Auto-calculate on input change
         document.querySelectorAll('input').forEach(input => {


### PR DESCRIPTION
## Summary
- extend propertyValuation plugin with getPropertyDetails API
- auto-populate year built and square footage when address loses focus
- test property details population flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a169b5d2c48326a6d7f83113729402