### PR TITLE
Update Stripe payment link for Pro upgrade

### DIFF
--- a/scripts/RetotalInvestmentCalculator.jsx
+++ b/scripts/RetotalInvestmentCalculator.jsx
@@ -92,7 +92,7 @@ const RetotalInvestmentCalculator = () => {
   };
 
   const handleProUpgrade = () => {
-    window.open('https://buy.stripe.com/test_your_payment_link', '_blank');
+    window.open('https://buy.stripe.com/28E6oGcgZeAL4Ofb5W9Ve00', '_blank');
   };
 
   const activatePro = () => {


### PR DESCRIPTION
## Summary
- update handleProUpgrade to open the production Stripe payment URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a17c6549708326899d07a2da8c7660