### PR TITLE
Add pricing details to tool cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
         <div class="tools-grid">
             <!-- Tool Cards -->
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">📊</div>
                 <h3 class="tool-title">Deal Analyzer</h3>
                 <div class="tool-users">For Investors & Flippers</div>
@@ -90,13 +91,19 @@
                     <li>Advanced ROI calculations</li>
                     <li>Market comparison engine</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
 
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">💰</div>
                 <h3 class="tool-title">Price Optimizer</h3>
                 <div class="tool-users">For Property Managers</div>
@@ -108,13 +115,19 @@
                     <li>Seasonal adjustments</li>
                     <li>Competition tracking</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
 
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">🤖</div>
                 <h3 class="tool-title">Realtor Assistant</h3>
                 <div class="tool-users">For Agents & Brokers</div>
@@ -126,13 +139,19 @@
                     <li>Email automation</li>
                     <li>Follow-up scheduler</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-new">New</span>
                 </div>
             </div>
 
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">👥</div>
                 <h3 class="tool-title">Tenant Screening</h3>
                 <div class="tool-users">For Landlords</div>
@@ -144,13 +163,19 @@
                     <li>Risk assessment</li>
                     <li>Predictive scoring</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>
 
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">🏗️</div>
                 <h3 class="tool-title">Zoning & Permits</h3>
                 <div class="tool-users">For Developers</div>
@@ -162,13 +187,19 @@
                     <li>Code compliance</li>
                     <li>Permit checklists</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-beta">Beta</span>
                 </div>
             </div>
 
             <div class="tool-card">
+                <span class="price-badge">$49/month</span>
                 <div class="tool-icon">🏡</div>
                 <h3 class="tool-title">Home Matchmaker</h3>
                 <div class="tool-users">For Buyers</div>
@@ -180,8 +211,13 @@
                     <li>Hidden gem finder</li>
                     <li>Commute analysis</li>
                 </ul>
+                <div class="pricing-info">
+                    <div class="free-tier">3 free uses/month</div>
+                    <div class="premium-tier">Starting at $49/month</div>
+                    <div class="premium-features">Unlimited analyses, save reports, export PDF</div>
+                </div>
                 <div class="tool-footer">
-                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Now</a>
+                    <a href="signup.html" class="btn-tool" style="text-decoration: none; display: inline-block;">Try Free</a>
                     <span class="tool-badge badge-live">Live</span>
                 </div>
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -362,6 +362,38 @@
             flex-shrink: 0;
         }
 
+        .price-badge {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--accent);
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 700;
+        }
+
+        .pricing-info {
+            margin-bottom: 1.5rem;
+        }
+
+        .free-tier,
+        .premium-tier {
+            font-size: 0.875rem;
+            font-weight: 600;
+            margin-bottom: 0.25rem;
+        }
+
+        .premium-tier {
+            color: var(--primary);
+        }
+
+        .premium-features {
+            color: var(--gray);
+            font-size: 0.85rem;
+        }
+
         .tool-footer {
             display: flex;
             justify-content: space-between;


### PR DESCRIPTION
## Summary
- Display $49/month price badge on each tool card with clear free tier and premium feature info.
- Replace generic "Try Now" buttons with "Try Free" calls to action.
- Style new pricing elements for prominence and consistency.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17df243b88326af2de764782f0596