### PR TITLE
Handle property valuation fetch errors

### DIFF
--- a/plugins/propertyValuation.js
+++ b/plugins/propertyValuation.js
@@ -1,19 +1,39 @@
 export async function getPropertyValuation({ address, city, state, zipcode, propertyType }) {
   const params = new URLSearchParams({ address, city, state, zipcode, propertyType });
   const url = `https://api.externalpropertyvaluation.com/estimate?${params.toString()}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error('Failed to fetch property valuation');
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch property valuation: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw new Error('Property valuation request timed out');
+    }
+    throw new Error(`Failed to fetch property valuation: ${err.message}`);
   }
-  return response.json();
 }
 
 export async function getPropertyDetails({ address, city, state, zipcode }) {
   const params = new URLSearchParams({ address, city, state, zipcode });
   const url = `https://api.externalpropertyvaluation.com/details?${params.toString()}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error('Failed to fetch property details');
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch property details: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw new Error('Property details request timed out');
+    }
+    throw new Error(`Failed to fetch property details: ${err.message}`);
   }
-  return response.json();
 }


### PR DESCRIPTION
## Summary
- wrap property valuation API calls in try/catch blocks
- surface HTTP status and status text in thrown errors
- add AbortController-based timeouts to prevent hanging requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29a50f1e08326a0fee26737e9ff0b