### PR TITLE
fix: correct property plugin paths for deal analyzer

### DIFF
--- a/deal-analyzer.html
+++ b/deal-analyzer.html
@@ -1035,7 +1035,7 @@
                 return;
             }
             try {
-                const { getPropertyDetails } = await import('../../plugins/propertyValuation.js');
+                const { getPropertyDetails } = await import('/plugins/propertyValuation.js');
                 const details = await getPropertyDetails({ address: street, city, state, zipcode });
                 document.getElementById('yearBuilt').value = details.yearBuilt || '';
                 document.getElementById('sqft').value = details.sqft || '';

--- a/tools/deal-analyzer/index.html
+++ b/tools/deal-analyzer/index.html
@@ -1035,7 +1035,7 @@
                 return;
             }
             try {
-                const { getPropertyDetails } = await import('../../plugins/propertyValuation.js');
+                const { getPropertyDetails } = await import('/plugins/propertyValuation.js');
                 const details = await getPropertyDetails({ address: street, city, state, zipcode });
                 document.getElementById('yearBuilt').value = details.yearBuilt || '';
                 document.getElementById('sqft').value = details.sqft || '';


### PR DESCRIPTION
## Summary
- reference property valuation plugin using root-relative paths
- ensure deal analyzer pages import property details module correctly

## Testing
- `npm test`
- `curl -I http://localhost:8123/plugins/propertyValuation.js`


------
https://chatgpt.com/codex/tasks/task_e_68b29a5af9808326805e3d1ed2bc14d7