### PR TITLE
Restore globals after property valuation tests

### DIFF
--- a/tests/propertyValuation.test.mjs
+++ b/tests/propertyValuation.test.mjs
@@ -1,25 +1,33 @@
 import assert from 'assert/strict';
 import { getPropertyValuation, getPropertyDetails } from '../plugins/propertyValuation.js';
 
+// Preserve originals so tests can safely mock globals
+const originalFetch = global.fetch;
+const originalDocument = global.document;
+
 async function testSuccess() {
   const expected = {
     propertyValue: 500000,
     confidenceScore: 87,
     lastUpdated: '2024-05-01T00:00:00Z'
   };
-  global.fetch = async (url) => ({
+  global.fetch = async () => ({
     ok: true,
     json: async () => expected,
   });
-  const result = await getPropertyValuation({
-    address: '123 Main St',
-    city: 'Anytown',
-    state: 'CA',
-    zipcode: '90210',
-    propertyType: 'Single Family'
-  });
-  assert.deepEqual(result, expected);
-  console.log('testSuccess passed');
+  try {
+    const result = await getPropertyValuation({
+      address: '123 Main St',
+      city: 'Anytown',
+      state: 'CA',
+      zipcode: '90210',
+      propertyType: 'Single Family'
+    });
+    assert.deepEqual(result, expected);
+    console.log('testSuccess passed');
+  } finally {
+    global.fetch = originalFetch;
+  }
 }
 
 async function testFailure() {
@@ -36,6 +44,8 @@ async function testFailure() {
   } catch (err) {
     threw = true;
     assert.ok(err instanceof Error);
+  } finally {
+    global.fetch = originalFetch;
   }
   assert.ok(threw, 'Expected error to be thrown');
   console.log('testFailure passed');
@@ -43,6 +53,7 @@ async function testFailure() {
 
 await testSuccess();
 await testFailure();
+
 async function testDetailsPopulate() {
   const expected = { yearBuilt: 1995, sqft: 2000 };
   global.fetch = async () => ({ ok: true, json: async () => expected });
@@ -55,18 +66,24 @@ async function testDetailsPopulate() {
     sqft: { value: '' }
   };
   global.document = { getElementById: id => elements[id] };
-  const details = await getPropertyDetails({
-    address: elements.street.value,
-    city: elements.city.value,
-    state: elements.state.value,
-    zipcode: elements.zipcode.value
-  });
-  document.getElementById('yearBuilt').value = details.yearBuilt;
-  document.getElementById('sqft').value = details.sqft;
-  assert.equal(elements.yearBuilt.value, expected.yearBuilt);
-  assert.equal(elements.sqft.value, expected.sqft);
-  console.log('testDetailsPopulate passed');
+  try {
+    const details = await getPropertyDetails({
+      address: elements.street.value,
+      city: elements.city.value,
+      state: elements.state.value,
+      zipcode: elements.zipcode.value
+    });
+    document.getElementById('yearBuilt').value = details.yearBuilt;
+    document.getElementById('sqft').value = details.sqft;
+    assert.equal(elements.yearBuilt.value, expected.yearBuilt);
+    assert.equal(elements.sqft.value, expected.sqft);
+    console.log('testDetailsPopulate passed');
+  } finally {
+    global.fetch = originalFetch;
+    global.document = originalDocument;
+  }
 }
 
 await testDetailsPopulate();
 console.log('All tests passed');
+


### PR DESCRIPTION
## Summary
- Preserve original `global.fetch` and `global.document` in propertyValuation tests
- Restore mocked globals after each test to avoid cross-test interference

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29a5f85808326a0c9d4b272ee5474