### PR TITLE
feat: scaffold deal analyzer MVP

### DIFF
--- a/app/api/deals/[id]/analyze/route.ts
+++ b/app/api/deals/[id]/analyze/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { analyze, DealInputs } from '@/lib/deal/analyze';
+import { z } from 'zod';
+
+const DEMO_ORG = 'demo-org';
+const DEMO_USER = 'demo-user';
+
+const InputSchema = z.object({
+  purchasePrice: z.number(),
+  rehabCost: z.number(),
+  arv: z.number(),
+  loanAmount: z.number(),
+  interestRate: z.number(),
+  monthlyIncome: z.number(),
+  holdingMonths: z.number()
+});
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const json = await req.json();
+  const inputs: DealInputs = InputSchema.parse(json);
+
+  const org = await prisma.org.findUnique({ where: { id: DEMO_ORG } });
+  const plan = org?.plan ?? 'starter';
+
+  const startOfMonth = new Date();
+  startOfMonth.setUTCDate(1); startOfMonth.setUTCHours(0,0,0,0);
+
+  const usage = await prisma.usageLedger.findUnique({
+    where: {
+      orgId_userId_tool_month: {
+        orgId: DEMO_ORG,
+        userId: DEMO_USER,
+        tool: 'deal_analyzer',
+        month: startOfMonth
+      }
+    }
+  });
+
+  if (plan !== 'pro' && usage && usage.count >= 3) {
+    return NextResponse.json({ error: 'Quota exceeded', upgrade: true }, { status: 402 });
+  }
+
+  const outputs = analyze(inputs);
+
+  await prisma.analysisRun.create({
+    data: {
+      orgId: DEMO_ORG,
+      dealId: params.id,
+      userId: DEMO_USER,
+      inputs,
+      outputs
+    }
+  });
+
+  await prisma.usageLedger.upsert({
+    where: {
+      orgId_userId_tool_month: {
+        orgId: DEMO_ORG,
+        userId: DEMO_USER,
+        tool: 'deal_analyzer',
+        month: startOfMonth
+      }
+    },
+    update: { count: { increment: 1 } },
+    create: {
+      orgId: DEMO_ORG,
+      userId: DEMO_USER,
+      tool: 'deal_analyzer',
+      month: startOfMonth,
+      count: 1
+    }
+  });
+
+  return NextResponse.json(outputs);
+}

--- a/app/api/deals/[id]/route.ts
+++ b/app/api/deals/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const DEMO_ORG = 'demo-org';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const deal = await prisma.deal.findFirst({ where: { id: params.id, orgId: DEMO_ORG } });
+  if (!deal) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(deal);
+}
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const body = await req.json();
+  const deal = await prisma.deal.update({
+    where: { id: params.id },
+    data: body
+  });
+  return NextResponse.json(deal);
+}

--- a/app/api/deals/[id]/share/route.ts
+++ b/app/api/deals/[id]/share/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { randomUUID } from 'crypto';
+
+const DEMO_ORG = 'demo-org';
+
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  const token = randomUUID();
+  const link = await prisma.sharedLink.create({
+    data: {
+      orgId: DEMO_ORG,
+      dealId: params.id,
+      token
+    }
+  });
+  return NextResponse.json({ url: `/share/${link.token}` });
+}

--- a/app/api/deals/route.ts
+++ b/app/api/deals/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+const DEMO_ORG = 'demo-org';
+const DEMO_USER = 'demo-user';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  const deal = await prisma.deal.create({
+    data: {
+      orgId: DEMO_ORG,
+      name: body.name ?? 'Untitled Deal',
+      purchasePrice: body.purchasePrice ?? 0,
+      rehabCost: body.rehabCost ?? 0,
+      arv: body.arv ?? 0,
+      holdingMonths: body.holdingMonths ?? 6,
+    }
+  });
+  return NextResponse.json(deal);
+}
+
+export async function GET() {
+  const deals = await prisma.deal.findMany({ where: { orgId: DEMO_ORG } });
+  return NextResponse.json(deals);
+}

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,0 +1,11 @@
+export default function BillingPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Billing</h1>
+      <p className="mb-4">Upgrade to Pro for unlimited analyses.</p>
+      <button className="px-4 py-2 bg-green-600 text-white rounded" disabled>
+        Upgrade to Pro
+      </button>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,10 @@
+import './globals.css';
+import React from 'react';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">REtotalAI</h1>
+    </main>
+  );
+}

--- a/app/tools/deal-analyzer/page.tsx
+++ b/app/tools/deal-analyzer/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+import { useState } from 'react';
+import { analyze, DealInputs, DealOutputs } from '@/lib/deal/analyze';
+
+export default function DealAnalyzerPage() {
+  const [inputs, setInputs] = useState<DealInputs>({
+    purchasePrice: 0,
+    rehabCost: 0,
+    arv: 0,
+    loanAmount: 0,
+    interestRate: 0.08,
+    monthlyIncome: 0,
+    holdingMonths: 6
+  });
+  const [outputs, setOutputs] = useState<DealOutputs | null>(null);
+  const [dealId, setDealId] = useState<string | null>(null);
+
+  const runAnalysis = async () => {
+    if (!dealId) {
+      const created = await fetch('/api/deals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(inputs)
+      }).then(r => r.json());
+      setDealId(created.id);
+    }
+    const local = analyze(inputs);
+    setOutputs(local);
+    if (dealId) {
+      await fetch(`/api/deals/${dealId}/analyze`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(inputs)
+      });
+    }
+  };
+
+  const update = (field: keyof DealInputs, value: number) => {
+    setInputs(prev => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <div className="flex p-8 gap-8">
+      <div className="w-1/2 space-y-4">
+        <h2 className="text-xl font-semibold">Inputs</h2>
+        {([
+          ['purchasePrice', 'Purchase Price'],
+          ['rehabCost', 'Rehab Cost'],
+          ['arv', 'After Repair Value'],
+          ['loanAmount', 'Loan Amount'],
+          ['interestRate', 'Interest Rate'],
+          ['monthlyIncome', 'Monthly Income'],
+          ['holdingMonths', 'Holding Months']
+        ] as [keyof DealInputs, string][]).map(([key, label]) => (
+          <div key={key} className="flex flex-col">
+            <label className="text-sm">{label}</label>
+            <input
+              type="number"
+              className="border p-2 rounded"
+              value={inputs[key]}
+              onChange={e => update(key, Number(e.target.value))}
+            />
+          </div>
+        ))}
+        <button
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+          onClick={runAnalysis}
+        >
+          Run Analysis
+        </button>
+      </div>
+      <div className="w-1/2 space-y-4">
+        <h2 className="text-xl font-semibold">Results</h2>
+        {outputs && (
+          <div className="grid grid-cols-2 gap-4">
+            <KPI label="Profit" value={`$${outputs.profit.toFixed(2)}`} />
+            <KPI label="ROI" value={`${(outputs.roi * 100).toFixed(2)}%`} />
+            <KPI label="Cash Needed" value={`$${outputs.cashNeeded.toFixed(2)}`} />
+            <KPI label="DSCR" value={outputs.dscr.toFixed(2)} />
+          </div>
+        )}
+        {outputs && outputs.warnings.length > 0 && (
+          <ul className="text-sm text-yellow-700 list-disc pl-5">
+            {outputs.warnings.map(w => (
+              <li key={w}>{w}</li>
+            ))}
+          </ul>
+        )}
+        <div className="pt-4">
+          <button className="px-3 py-1 border rounded mr-2" disabled>
+            Export PDF
+          </button>
+          <button className="px-3 py-1 border rounded mr-2" disabled>
+            Export CSV
+          </button>
+          <button className="px-3 py-1 border rounded" disabled>
+            Share Link
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function KPI({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-4 border rounded bg-white">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="text-lg font-bold">{value}</div>
+    </div>
+  );
+}

--- a/lib/deal/analyze.ts
+++ b/lib/deal/analyze.ts
@@ -1,0 +1,42 @@
+export type DealInputs = {
+  purchasePrice: number;
+  rehabCost: number;
+  arv: number;
+  loanAmount: number;
+  interestRate: number; // annual rate e.g. 0.08
+  monthlyIncome: number;
+  holdingMonths: number;
+};
+
+export type DealOutputs = {
+  cashNeeded: number;
+  profit: number;
+  roi: number;
+  dscr: number;
+  breakevenARV: number;
+  warnings: string[];
+};
+
+export function analyze(inputs: DealInputs): DealOutputs {
+  const cashNeeded = inputs.purchasePrice + inputs.rehabCost - inputs.loanAmount;
+  const profit = inputs.arv - inputs.purchasePrice - inputs.rehabCost;
+  const roi = cashNeeded !== 0 ? profit / cashNeeded : 0;
+  const monthlyDebtService = inputs.loanAmount * inputs.interestRate / 12;
+  const dscr = monthlyDebtService !== 0 ? inputs.monthlyIncome / monthlyDebtService : 0;
+  const breakevenARV = inputs.purchasePrice + inputs.rehabCost + cashNeeded;
+
+  const warnings: string[] = [];
+  // stress test: +200bps rate, +10% rehab cost
+  const stressedDebtService = inputs.loanAmount * (inputs.interestRate + 0.02) / 12;
+  const stressedDSCR = stressedDebtService !== 0 ? inputs.monthlyIncome / stressedDebtService : 0;
+  const stressedROI = (inputs.arv - inputs.purchasePrice - inputs.rehabCost * 1.1) /
+    (inputs.purchasePrice + inputs.rehabCost * 1.1 - inputs.loanAmount);
+  if (stressedDSCR < 1) {
+    warnings.push('DSCR below 1.0 under stress test');
+  }
+  if (stressedROI < 0) {
+    warnings.push('Negative ROI under stress test');
+  }
+
+  return { cashNeeded, profit, roi, dscr, breakevenARV, warnings };
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({ log: ['query'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -2,24 +2,31 @@
   "name": "retotalai-site",
   "version": "1.0.0",
   "description": "REtotalAI modular real estate tools site",
-  "main": "index.html",
+  "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "serve .",
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "test": "node tests/propertyValuation.test.mjs"
   },
   "keywords": [],
   "author": "REtotalAI Team",
   "license": "MIT",
   "dependencies": {
+    "@prisma/client": "^5.13.0",
     "chart.js": "^4.4.1",
-    "lucide-react": "^0.368.0"
+    "lucide-react": "^0.368.0",
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.2.0"
+    "prisma": "^5.13.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.14",
+    "typescript": "^5.3.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,143 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Org {
+  id            String         @id @default(uuid())
+  name          String
+  plan          String         @default("starter")
+  memberships   Membership[]
+  deals         Deal[]
+  subscriptions Subscription[]
+  usage         UsageLedger[]
+  auditLogs     AuditLog[]
+}
+
+model User {
+  id           String        @id @default(uuid())
+  email        String        @unique
+  name         String?
+  memberships  Membership[]
+  analysisRuns AnalysisRun[]
+  usage        UsageLedger[]
+  auditLogs    AuditLog[]
+}
+
+model Membership {
+  id     String @id @default(uuid())
+  orgId  String
+  userId String
+  role   String @default("member")
+  org    Org    @relation(fields: [orgId], references: [id])
+  user   User   @relation(fields: [userId], references: [id])
+}
+
+model Subscription {
+  id        String   @id @default(uuid())
+  orgId     String
+  plan      String
+  createdAt DateTime @default(now())
+  org       Org      @relation(fields: [orgId], references: [id])
+}
+
+model Deal {
+  id               String             @id @default(uuid())
+  orgId            String
+  name             String
+  purchasePrice    Decimal            @db.Decimal(10,2)
+  rehabCost        Decimal            @db.Decimal(10,2)
+  arv              Decimal            @db.Decimal(10,2)
+  holdingMonths    Int
+  loanTerms        LoanTerms?
+  holdingCosts     HoldingCosts?
+  incomeAssumptions IncomeAssumptions?
+  analysisRuns     AnalysisRun[]
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @updatedAt
+  org              Org                @relation(fields: [orgId], references: [id])
+}
+
+model LoanTerms {
+  id          String  @id @default(uuid())
+  orgId       String
+  dealId      String  @unique
+  loanAmount  Decimal @db.Decimal(10,2)
+  interestRate Float
+  termMonths  Int
+  deal        Deal    @relation(fields: [dealId], references: [id])
+  org         Org     @relation(fields: [orgId], references: [id])
+}
+
+model HoldingCosts {
+  id        String  @id @default(uuid())
+  orgId     String
+  dealId    String  @unique
+  taxes     Decimal @db.Decimal(10,2) @default(0)
+  insurance Decimal @db.Decimal(10,2) @default(0)
+  utilities Decimal @db.Decimal(10,2) @default(0)
+  other     Decimal @db.Decimal(10,2) @default(0)
+  deal      Deal    @relation(fields: [dealId], references: [id])
+  org       Org     @relation(fields: [orgId], references: [id])
+}
+
+model IncomeAssumptions {
+  id          String  @id @default(uuid())
+  orgId       String
+  dealId      String  @unique
+  rent        Decimal @db.Decimal(10,2) @default(0)
+  otherIncome Decimal @db.Decimal(10,2) @default(0)
+  deal        Deal    @relation(fields: [dealId], references: [id])
+  org         Org     @relation(fields: [orgId], references: [id])
+}
+
+model AnalysisRun {
+  id        String   @id @default(uuid())
+  orgId     String
+  dealId    String
+  userId    String
+  inputs    Json
+  outputs   Json
+  createdAt DateTime @default(now())
+  deal      Deal     @relation(fields: [dealId], references: [id])
+  org       Org      @relation(fields: [orgId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
+}
+
+model SharedLink {
+  id        String   @id @default(uuid())
+  orgId     String
+  dealId    String
+  token     String   @unique
+  createdAt DateTime @default(now())
+  deal      Deal     @relation(fields: [dealId], references: [id])
+  org       Org      @relation(fields: [orgId], references: [id])
+}
+
+model UsageLedger {
+  id       String   @id @default(uuid())
+  orgId    String
+  userId   String
+  tool     String
+  month    DateTime
+  count    Int      @default(0)
+  org      Org      @relation(fields: [orgId], references: [id])
+  user     User     @relation(fields: [userId], references: [id])
+
+  @@unique([orgId, userId, tool, month], name: "orgId_userId_tool_month")
+}
+
+model AuditLog {
+  id        String   @id @default(uuid())
+  orgId     String
+  userId    String?
+  action    String
+  meta      Json?
+  createdAt DateTime @default(now())
+  org       Org      @relation(fields: [orgId], references: [id])
+  user      User?    @relation(fields: [userId], references: [id])
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up Prisma schema and Next.js scaffolding for deal analyzer
- implement analysis engine with stress testing
- add API routes, quota enforcement, and basic UI

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*
- `npx prisma migrate dev --name init_deal_analyzer` *(fails: 403 Forbidden - GET https://registry.npmjs.org/prisma)*
- `npm run dev` *(fails: next: not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29c451a288326ad52d4f151406aa6