### PR TITLE
Revise Prisma schema for richer data models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,143 +1,182 @@
-generator client {
-  provider = "prisma-client-js"
-}
-
-datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
-}
+generator client { provider = "prisma-client-js" }
+datasource db { provider = "postgresql"; url = env("DATABASE_URL") }
 
 model Org {
-  id            String         @id @default(uuid())
-  name          String
-  plan          String         @default("starter")
-  memberships   Membership[]
-  deals         Deal[]
-  subscriptions Subscription[]
-  usage         UsageLedger[]
-  auditLogs     AuditLog[]
+  id             String        @id @default(uuid())
+  name           String
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
+  memberships    Membership[]
+  deals          Deal[]
+  subscription   Subscription?
+  analysisRuns   AnalysisRun[]
+  usageLedgers   UsageLedger[]
+  auditLogs      AuditLog[]
+  sharedLinks    SharedLink[]
 }
 
 model User {
-  id           String        @id @default(uuid())
-  email        String        @unique
-  name         String?
-  memberships  Membership[]
-  analysisRuns AnalysisRun[]
-  usage        UsageLedger[]
-  auditLogs    AuditLog[]
+  id            String        @id @default(uuid())
+  email         String        @unique
+  name          String?
+  mfaEnabled    Boolean       @default(false)
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
+  memberships   Membership[]
+  createdDeals  Deal[]        @relation("DealCreatedBy")
+  runs          AnalysisRun[] @relation("RunBy")
+  sharedLinks   SharedLink[]  @relation("SharedBy")
+  usageLedgers  UsageLedger[]
+  auditLogs     AuditLog[]    @relation("Actor")
 }
 
 model Membership {
-  id     String @id @default(uuid())
-  orgId  String
-  userId String
-  role   String @default("member")
-  org    Org    @relation(fields: [orgId], references: [id])
-  user   User   @relation(fields: [userId], references: [id])
+  id        String   @id @default(uuid())
+  org       Org      @relation(fields: [orgId], references: [id])
+  orgId     String
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  role      Role
+  createdAt DateTime @default(now())
+  @@unique([orgId, userId])
 }
+
+enum Role { owner admin member viewer }
 
 model Subscription {
-  id        String   @id @default(uuid())
-  orgId     String
-  plan      String
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id])
+  id                    String     @id @default(uuid())
+  org                   Org        @relation(fields: [orgId], references: [id])
+  orgId                 String     @unique
+  plan                  Plan
+  status                SubStatus
+  currentPeriodStart    DateTime
+  currentPeriodEnd      DateTime
+  stripeCustomerId      String?
+  stripeSubscriptionId  String?
+  createdAt             DateTime   @default(now())
+  updatedAt             DateTime   @updatedAt
 }
+enum Plan { starter pro }
+enum SubStatus { trialing active past_due canceled }
 
 model Deal {
-  id               String             @id @default(uuid())
-  orgId            String
-  name             String
-  purchasePrice    Decimal            @db.Decimal(10,2)
-  rehabCost        Decimal            @db.Decimal(10,2)
-  arv              Decimal            @db.Decimal(10,2)
-  holdingMonths    Int
-  loanTerms        LoanTerms?
-  holdingCosts     HoldingCosts?
+  id                String              @id @default(uuid())
+  org               Org                 @relation(fields: [orgId], references: [id])
+  orgId             String
+  createdBy         User?               @relation("DealCreatedBy", fields: [createdById], references: [id])
+  createdById       String?
+  title             String
+  propertyAddress   String?
+  propertyCity      String?
+  propertyState     String?
+  propertyPostalCode String?
+  lat               Float?
+  lon               Float?
+  arv               Decimal?
+  purchasePrice     Decimal
+  rehabCost         Decimal             @default(0)
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt
+  deletedAt         DateTime?
+  loanTerms         LoanTerms?
+  holdingCosts      HoldingCosts?
   incomeAssumptions IncomeAssumptions?
-  analysisRuns     AnalysisRun[]
-  createdAt        DateTime           @default(now())
-  updatedAt        DateTime           @updatedAt
-  org              Org                @relation(fields: [orgId], references: [id])
+  runs              AnalysisRun[]
+  shares            SharedLink[]
 }
 
 model LoanTerms {
-  id          String  @id @default(uuid())
-  orgId       String
-  dealId      String  @unique
-  loanAmount  Decimal @db.Decimal(10,2)
-  interestRate Float
-  termMonths  Int
-  deal        Deal    @relation(fields: [dealId], references: [id])
-  org         Org     @relation(fields: [orgId], references: [id])
+  id            String  @id @default(uuid())
+  deal          Deal    @relation(fields: [dealId], references: [id])
+  dealId        String  @unique
+  loanType      LoanType
+  ltv           Decimal?
+  interestRate  Decimal?
+  points        Decimal?
+  termMonths    Int?
+  interestOnly  Boolean?
+  closingCosts  Decimal?
+  downPayment   Decimal?
+  createdAt     DateTime @default(now())
 }
+enum LoanType { cash hard_money conventional dscr }
 
 model HoldingCosts {
-  id        String  @id @default(uuid())
-  orgId     String
-  dealId    String  @unique
-  taxes     Decimal @db.Decimal(10,2) @default(0)
-  insurance Decimal @db.Decimal(10,2) @default(0)
-  utilities Decimal @db.Decimal(10,2) @default(0)
-  other     Decimal @db.Decimal(10,2) @default(0)
-  deal      Deal    @relation(fields: [dealId], references: [id])
-  org       Org     @relation(fields: [orgId], references: [id])
+  id                    String  @id @default(uuid())
+  deal                  Deal    @relation(fields: [dealId], references: [id])
+  dealId                String  @unique
+  holdMonths            Int     @default(6)
+  taxesMonthly          Decimal?
+  insuranceMonthly      Decimal?
+  utilitiesMonthly      Decimal?
+  hoaMonthly            Decimal?
+  maintenanceMonthly    Decimal?
+  vacancyRate           Decimal?
+  propertyManagementPct Decimal?
+  createdAt             DateTime @default(now())
 }
 
 model IncomeAssumptions {
-  id          String  @id @default(uuid())
-  orgId       String
-  dealId      String  @unique
-  rent        Decimal @db.Decimal(10,2) @default(0)
-  otherIncome Decimal @db.Decimal(10,2) @default(0)
-  deal        Deal    @relation(fields: [dealId], references: [id])
-  org         Org     @relation(fields: [orgId], references: [id])
+  id            String  @id @default(uuid())
+  deal          Deal    @relation(fields: [dealId], references: [id])
+  dealId        String  @unique
+  monthlyRent   Decimal?
+  otherIncome   Decimal? @default(0)
+  capexMonthly  Decimal? @default(0)
+  createdAt     DateTime @default(now())
 }
 
 model AnalysisRun {
   id        String   @id @default(uuid())
+  org       Org      @relation(fields: [orgId], references: [id])
   orgId     String
+  deal      Deal     @relation(fields: [dealId], references: [id])
   dealId    String
-  userId    String
+  runBy     User?    @relation("RunBy", fields: [runById], references: [id])
+  runById   String?
   inputs    Json
   outputs   Json
+  version   String
   createdAt DateTime @default(now())
-  deal      Deal     @relation(fields: [dealId], references: [id])
-  org       Org      @relation(fields: [orgId], references: [id])
-  user      User     @relation(fields: [userId], references: [id])
+  @@index([orgId, dealId, createdAt])
 }
 
 model SharedLink {
-  id        String   @id @default(uuid())
-  orgId     String
-  dealId    String
-  token     String   @unique
-  createdAt DateTime @default(now())
-  deal      Deal     @relation(fields: [dealId], references: [id])
-  org       Org      @relation(fields: [orgId], references: [id])
+  id         String   @id @default(uuid())
+  org        Org      @relation(fields: [orgId], references: [id])
+  orgId      String
+  deal       Deal     @relation(fields: [dealId], references: [id])
+  dealId     String
+  token      String   @unique
+  expiresAt  DateTime?
+  createdBy  User?    @relation("SharedBy", fields: [createdById], references: [id])
+  createdById String?
+  createdAt  DateTime @default(now())
 }
 
 model UsageLedger {
-  id       String   @id @default(uuid())
-  orgId    String
-  userId   String
-  tool     String
-  month    DateTime
-  count    Int      @default(0)
-  org      Org      @relation(fields: [orgId], references: [id])
-  user     User     @relation(fields: [userId], references: [id])
-
-  @@unique([orgId, userId, tool, month], name: "orgId_userId_tool_month")
+  id              String  @id @default(uuid())
+  org             Org     @relation(fields: [orgId], references: [id])
+  orgId           String
+  user            User    @relation(fields: [userId], references: [id])
+  userId          String
+  tool            Tool
+  periodStartDate DateTime
+  count           Int     @default(0)
+  lastUsedAt      DateTime?
+  @@unique([orgId, userId, tool, periodStartDate])
 }
+enum Tool { deal_analyzer }
 
 model AuditLog {
-  id        String   @id @default(uuid())
-  orgId     String
-  userId    String?
-  action    String
-  meta      Json?
-  createdAt DateTime @default(now())
-  org       Org      @relation(fields: [orgId], references: [id])
-  user      User?    @relation(fields: [userId], references: [id])
+  id          String   @id @default(uuid())
+  org         Org      @relation(fields: [orgId], references: [id])
+  orgId       String
+  actorUser   User?    @relation("Actor", fields: [actorUserId], references: [id])
+  actorUserId String?
+  action      String
+  entity      String?
+  ip          String?
+  userAgent   String?
+  createdAt   DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- overhaul `prisma/schema.prisma` to define detailed models for orgs, users, memberships, subscriptions, deals, analysis runs, and more

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2a5b68f1c832693c2078d9f9f5834