### PR TITLE
Simplify Prisma schema to minimal Org and Deal models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,182 +1,27 @@
-generator client { provider = "prisma-client-js" }
-datasource db { provider = "postgresql"; url = env("DATABASE_URL") }
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
 
 model Org {
-  id           String        @id @default(uuid())
-  name         String
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  memberships  Membership[]
-  deals        Deal[]
-  subscription Subscription?
-  analysisRuns AnalysisRun[]
-  usageLedgers UsageLedger[]
-  auditLogs    AuditLog[]
-  sharedLinks  SharedLink[]
-}
-
-model User {
-  id           String        @id @default(uuid())
-  email        String        @unique
-  name         String?
-  mfaEnabled   Boolean       @default(false)
-  createdAt    DateTime      @default(now())
-  updatedAt    DateTime      @updatedAt
-  memberships  Membership[]
-  createdDeals Deal[]        @relation("DealCreatedBy")
-  runs         AnalysisRun[] @relation("RunBy")
-  sharedLinks  SharedLink[]  @relation("SharedBy")
-  usageLedgers UsageLedger[]
-  auditLogs    AuditLog[]    @relation("Actor")
-}
-
-model Membership {
   id        String   @id @default(uuid())
-  org       Org      @relation(fields: [orgId], references: [id])
-  orgId     String
-  user      User     @relation(fields: [userId], references: [id])
-  userId    String
-  role      Role
+  name      String
+  deals     Deal[]
   createdAt DateTime @default(now())
-  @@unique([orgId, userId])
+  updatedAt DateTime @updatedAt
 }
-enum Role { owner admin member viewer }
-
-model Subscription {
-  id                   String   @id @default(uuid())
-  org                  Org      @relation(fields: [orgId], references: [id])
-  orgId                String   @unique
-  plan                 Plan
-  status               SubStatus
-  currentPeriodStart   DateTime
-  currentPeriodEnd     DateTime
-  stripeCustomerId     String?
-  stripeSubscriptionId String?
-  createdAt            DateTime @default(now())
-  updatedAt            DateTime @updatedAt
-}
-enum Plan { starter pro }
-enum SubStatus { trialing active past_due canceled }
 
 model Deal {
-  id                 String              @id @default(uuid())
-  org                Org                 @relation(fields: [orgId], references: [id])
-  orgId              String
-  createdBy          User?               @relation("DealCreatedBy", fields: [createdById], references: [id])
-  createdById        String?
-  title              String
-  propertyAddress    String?
-  propertyCity       String?
-  propertyState      String?
-  propertyPostalCode String?
-  lat                Float?
-  lon                Float?
-  arv                Decimal?
-  purchasePrice      Decimal
-  rehabCost          Decimal             @default(0)
-  createdAt          DateTime            @default(now())
-  updatedAt          DateTime            @updatedAt
-  deletedAt          DateTime?
-  loanTerms          LoanTerms?
-  holdingCosts       HoldingCosts?
-  incomeAssumptions  IncomeAssumptions?
-  runs               AnalysisRun[]
-  shares             SharedLink[]
+  id            String   @id @default(uuid())
+  org           Org      @relation(fields: [orgId], references: [id])
+  orgId         String
+  title         String
+  purchasePrice Float
+  rehabCost     Float    @default(0)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 }
-
-model LoanTerms {
-  id           String   @id @default(uuid())
-  deal         Deal     @relation(fields: [dealId], references: [id])
-  dealId       String   @unique
-  loanType     LoanType
-  ltv          Decimal?
-  interestRate Decimal?
-  points       Decimal?
-  termMonths   Int?
-  interestOnly Boolean?
-  closingCosts Decimal?
-  downPayment  Decimal?
-  createdAt    DateTime @default(now())
-}
-enum LoanType { cash hard_money conventional dscr }
-
-model HoldingCosts {
-  id                    String   @id @default(uuid())
-  deal                  Deal     @relation(fields: [dealId], references: [id])
-  dealId                String   @unique
-  holdMonths            Int      @default(6)
-  taxesMonthly          Decimal?
-  insuranceMonthly      Decimal?
-  utilitiesMonthly      Decimal?
-  hoaMonthly            Decimal?
-  maintenanceMonthly    Decimal?
-  vacancyRate           Decimal?
-  propertyManagementPct Decimal?
-  createdAt             DateTime @default(now())
-}
-
-model IncomeAssumptions {
-  id           String   @id @default(uuid())
-  deal         Deal     @relation(fields: [dealId], references: [id])
-  dealId       String   @unique
-  monthlyRent  Decimal?
-  otherIncome  Decimal? @default(0)
-  capexMonthly Decimal? @default(0)
-  createdAt    DateTime @default(now())
-}
-
-model AnalysisRun {
-  id        String   @id @default(uuid())
-  org       Org      @relation(fields: [orgId], references: [id])
-  orgId     String
-  deal      Deal     @relation(fields: [dealId], references: [id])
-  dealId    String
-  runBy     User?    @relation("RunBy", fields: [runById], references: [id])
-  runById   String?
-  inputs    Json
-  outputs   Json
-  version   String
-  createdAt DateTime @default(now())
-  @@index([orgId, dealId, createdAt])
-}
-
-model SharedLink {
-  id          String   @id @default(uuid())
-  org         Org      @relation(fields: [orgId], references: [id])
-  orgId       String
-  deal        Deal     @relation(fields: [dealId], references: [id])
-  dealId      String
-  token       String   @unique
-  expiresAt   DateTime?
-  createdBy   User?    @relation("SharedBy", fields: [createdById], references: [id])
-  createdById String?
-  createdAt   DateTime @default(now())
-}
-
-model UsageLedger {
-  id              String   @id @default(uuid())
-  org             Org      @relation(fields: [orgId], references: [id])
-  orgId           String
-  user            User     @relation(fields: [userId], references: [id])
-  userId          String
-  tool            Tool
-  periodStartDate DateTime
-  count           Int      @default(0)
-  lastUsedAt      DateTime?
-  @@unique([orgId, userId, tool, periodStartDate])
-}
-enum Tool { deal_analyzer }
-
-model AuditLog {
-  id          String   @id @default(uuid())
-  org         Org      @relation(fields: [orgId], references: [id])
-  orgId       String
-  actorUser   User?    @relation("Actor", fields: [actorUserId], references: [id])
-  actorUserId String?
-  action      String
-  entity      String?
-  ip          String?
-  userAgent   String?
-  createdAt   DateTime @default(now())
-}
-


### PR DESCRIPTION
## Summary
- replace prisma schema with minimal `Org` and `Deal` models

## Testing
- `npx prisma format`
- `npx prisma validate`
- `npx prisma migrate dev --name init_min` *(fails: P1001 Can't reach database server at `localhost:5432`)*
- `npx prisma generate`
- `npm run dev` *(fails: missing TypeScript dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b2acaa3d3083269c4876d0736f660f