### PR TITLE
Add Deal Analyzer strategy-specific pages

### DIFF
--- a/tools/deal-analyzer/brrrr.html
+++ b/tools/deal-analyzer/brrrr.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deal Analyzer - REtotalAI</title>
+    <title>Deal Analyzer - BRRRR</title>
     <style>
         * {
             margin: 0;
@@ -136,7 +136,7 @@
 
         /* Strategy Selector */
         .strategy-selector {
-            display: flex;
+            display: none;
             gap: 1rem;
             justify-content: center;
             margin-bottom: 2rem;
@@ -499,9 +499,9 @@
 
         <!-- Strategy Selector -->
         <div class="strategy-selector">
-            <button class="strategy-btn active" data-strategy="rental">Buy & Hold</button>
+            <button class="strategy-btn" data-strategy="rental">Buy & Hold</button>
             <button class="strategy-btn" data-strategy="flip">Fix & Flip</button>
-            <button class="strategy-btn" data-strategy="brrrr">BRRRR</button>
+            <button class="strategy-btn active" data-strategy="brrrr">BRRRR</button>
             <button class="strategy-btn" data-strategy="airbnb">Short-Term Rental</button>
         </div>
 
@@ -1072,6 +1072,8 @@
             // Calculate with example data
             calculateDeal();
         });
-    </script>
+    
+switchStrategy('brrrr');
+</script>
 </body>
 </html>

--- a/tools/deal-analyzer/buy-hold.html
+++ b/tools/deal-analyzer/buy-hold.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deal Analyzer - REtotalAI</title>
+    <title>Deal Analyzer - Buy & Hold</title>
     <style>
         * {
             margin: 0;
@@ -136,7 +136,7 @@
 
         /* Strategy Selector */
         .strategy-selector {
-            display: flex;
+            display: none;
             gap: 1rem;
             justify-content: center;
             margin-bottom: 2rem;
@@ -1072,6 +1072,8 @@
             // Calculate with example data
             calculateDeal();
         });
-    </script>
+    
+switchStrategy('rental');
+</script>
 </body>
 </html>

--- a/tools/deal-analyzer/flip.html
+++ b/tools/deal-analyzer/flip.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Deal Analyzer - REtotalAI</title>
+    <title>Deal Analyzer - Fix & Flip</title>
     <style>
         * {
             margin: 0;
@@ -136,7 +136,7 @@
 
         /* Strategy Selector */
         .strategy-selector {
-            display: flex;
+            display: none;
             gap: 1rem;
             justify-content: center;
             margin-bottom: 2rem;
@@ -499,8 +499,8 @@
 
         <!-- Strategy Selector -->
         <div class="strategy-selector">
-            <button class="strategy-btn active" data-strategy="rental">Buy & Hold</button>
-            <button class="strategy-btn" data-strategy="flip">Fix & Flip</button>
+            <button class="strategy-btn" data-strategy="rental">Buy & Hold</button>
+            <button class="strategy-btn active" data-strategy="flip">Fix & Flip</button>
             <button class="strategy-btn" data-strategy="brrrr">BRRRR</button>
             <button class="strategy-btn" data-strategy="airbnb">Short-Term Rental</button>
         </div>
@@ -1072,6 +1072,8 @@
             // Calculate with example data
             calculateDeal();
         });
-    </script>
+    
+switchStrategy('flip');
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace main deal analyzer HTML with canvas version
- Add dedicated Flip, Buy & Hold, and BRRRR analyzer pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b36428ae8483268cd5a98fe5f54804