### PR TITLE
feat: integrate FinalOutputsPanel into deal analyzer

### DIFF
--- a/src/pages/DealAnalyzer.tsx
+++ b/src/pages/DealAnalyzer.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import ClosingCostsSection, { Totals as ClosingTotals } from "./ClosingCostsSection";
 import HoldCostsSection, { HoldTotals } from "./HoldCostsSection";
+import FinalOutputsPanel from "../components/FinalOutputsPanel";
 
 export default function DealAnalyzer() {
   // ------------------------
@@ -18,13 +19,6 @@ export default function DealAnalyzer() {
   const [closingTotals, setClosingTotals] = useState<ClosingTotals>({ purchase: 0, exit: 0, total: 0, financeable: 0 });
   const [holdTotals, setHoldTotals] = useState<HoldTotals>({ monthly: 0, oneTime: 0, monthsHeld: 0, total: 0 });
   const [monthlyOpex, setMonthlyOpex] = useState(0);
-
-  // ------------------------
-  // Example Outputs
-  // ------------------------
-  const cashToClose = purchasePrice + rehab + closingTotals.purchase - loanAmount - closingTotals.financeable;
-  const flipProfit = arv - (purchasePrice + rehab + closingTotals.total + holdTotals.total); // simplified
-  const dscr = monthlyRent > 0 && monthlyOpex > 0 ? (monthlyRent - monthlyOpex) / 1200 : 0; // 1200 = example P&I
 
   return (
     <div className="space-y-8 p-6">
@@ -50,13 +44,25 @@ export default function DealAnalyzer() {
         onChange={(_, totals) => setMonthlyOpex(totals.total)}
       />
 
-      {/* Outputs */}
-      <div className="rounded-2xl bg-white p-4 shadow-sm">
-        <h2 className="text-lg font-semibold text-slate-800">Summary</h2>
-        <p>Cash to Close: ${cashToClose.toLocaleString()}</p>
-        <p>Flip Profit: ${flipProfit.toLocaleString()}</p>
-        <p>DSCR (Rental): {dscr.toFixed(2)}</p>
-      </div>
+      {/* Final Outputs / Summary */}
+      <FinalOutputsPanel
+        dealType={"flip" /* or "rental" / "brrrr" based on mode */}
+        inputs={{
+          purchasePrice,
+          rehab,
+          arv, // or salePrice
+          loanAmount,
+          annualRate: 0.12, // example; wire from Financing section if you have it
+          termYears: 30, // example; wire from Financing
+          interestOnly: false, // example; wire from Financing
+          monthlyRent,
+          opexMonthly: monthlyOpex, // from HoldCosts opex
+          // monthlyDebtService: myMonthlyPAndI, // if you already compute this elsewhere, pass it to override
+          rehabFinanced: false,
+        }}
+        closing={closingTotals} // from ClosingCostsSection onChange
+        hold={{ total: holdTotals.total, monthly: holdTotals.monthly }} // from HoldCostsSection (carry)
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- render `FinalOutputsPanel` in DealAnalyzer to show final summary metrics
- wire closing and hold totals into FinalOutputsPanel

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b68eaf8d948326a2bde240e1508bd9