### PR TITLE
fix: use percent type value

### DIFF
--- a/src/components/ClosingCostsSection.tsx
+++ b/src/components/ClosingCostsSection.tsx
@@ -206,7 +206,7 @@ const ItemRow: React.FC<{
         onChange={(v) => onChange({ type: v as ItemType })}
         options={[
           { value: "fixed", label: "Fixed $" },
-          { value: "%", label: "%" },
+          { value: "percent", label: "%" },
         ]}
       />
       <div className="col-span-3">


### PR DESCRIPTION
## Summary
- ensure percent-based closing cost items store `percent`

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6925be2f88326b0beaafc3d2dc799