### PR TITLE
fix: use percent item type

### DIFF
--- a/app/tools/deal-analyzer/ClosingCostsSection.tsx
+++ b/app/tools/deal-analyzer/ClosingCostsSection.tsx
@@ -206,7 +206,7 @@ const ItemRow: React.FC<{
         onChange={(v) => onChange({ type: v as ItemType })}
         options={[
           { value: "fixed", label: "Fixed $" },
-          { value: "%", label: "%" },
+          { value: "percent", label: "%" },
         ]}
       />
       <div className="col-span-3">

--- a/src/components/ClosingCostsSection.tsx
+++ b/src/components/ClosingCostsSection.tsx
@@ -206,7 +206,7 @@ const ItemRow: React.FC<{
         onChange={(v) => onChange({ type: v as ItemType })}
         options={[
           { value: "fixed", label: "Fixed $" },
-          { value: "%", label: "%" },
+          { value: "percent", label: "%" },
         ]}
       />
       <div className="col-span-3">


### PR DESCRIPTION
## Summary
- align percent type selector values with state checks

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b6922a79f48326944b8ec78bcb23c4