### PR TITLE
refactor: update DealAnalyzer page imports

### DIFF
--- a/src/components/ClosingCostsSection.tsx
+++ b/src/components/ClosingCostsSection.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface Totals {
+  purchase: number;
+  exit: number;
+  total: number;
+  financeable: number;
+}
+
+export default function ClosingCostsSection(
+  _props: { bases: any; onChange?: (state: any, totals: Totals) => void }
+) {
+  return null;
+}

--- a/src/components/FinalOutputsPanel.tsx
+++ b/src/components/FinalOutputsPanel.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function FinalOutputsPanel(_props: any) {
+  return null;
+}

--- a/src/components/HoldCostsSection.tsx
+++ b/src/components/HoldCostsSection.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface HoldTotals {
+  monthly: number;
+  oneTime: number;
+  monthsHeld: number;
+  total: number;
+}
+
+export default function HoldCostsSection(
+  _props: { kind: string; bases: any; onChange?: (state: any, totals: HoldTotals) => void }
+) {
+  return null;
+}

--- a/src/pages/DealAnalyzer.tsx
+++ b/src/pages/DealAnalyzer.tsx
@@ -1,6 +1,7 @@
+// src/pages/DealAnalyzer.tsx
 import React, { useState } from "react";
-import ClosingCostsSection, { Totals as ClosingTotals } from "./ClosingCostsSection";
-import HoldCostsSection, { HoldTotals } from "./HoldCostsSection";
+import ClosingCostsSection, { Totals as ClosingTotals } from "../components/ClosingCostsSection";
+import HoldCostsSection, { HoldTotals } from "../components/HoldCostsSection";
 import FinalOutputsPanel from "../components/FinalOutputsPanel";
 
 export default function DealAnalyzer() {
@@ -66,4 +67,3 @@ export default function DealAnalyzer() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- refactor DealAnalyzer page to import sections from components directory
- add placeholder components for closing costs, holding costs, and final output panel

## Testing
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b7c857558c8326a6c55f9aca2b8873