### PR TITLE
Avoid forcing JSON content-type in API helper

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -3,8 +3,15 @@ export const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export async function api(path: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers || {});
-  headers.set("Content-Type", "application/json");
-  headers.set("x-user-id", "dev-user-1"); // temporary user id
+
+  const body = (init as any).body;
+  const isFormData =
+    typeof FormData !== "undefined" && body instanceof FormData;
+
+  if (body != null && !isFormData && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  headers.set("x-user-id", "dev-user-1"); // temp dev identity
 
   const res = await fetch(`${BASE_URL}${path}`, { ...init, headers });
   if (res.status === 402) {


### PR DESCRIPTION
## Summary
- Update API helper to avoid setting `Content-Type` when sending `FormData` or no body
- Preserve ability to set custom headers while still defaulting to JSON when appropriate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa4c42108326912119774eae3738