### PR TITLE
Allow CORS from Vercel frontend

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,8 +32,8 @@ try {
 const app = express();
 app.use(cors({
   origin: [
-    "https://YOUR-VERCEL-APP.vercel.app", // (we'll paste your real URL after we deploy the site)
-    "http://localhost:3000"               // keep for safety; fine to leave
+    "https://retotalai.vercel.app", // deployed Vercel frontend
+    "http://localhost:3000"         // keep for local development
   ],
   credentials: false
 }));

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "body-parser": "^2.2.0",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "stripe": "^18.5.0"
       }
@@ -122,6 +123,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/debug": {
@@ -505,6 +519,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/server/package.json
+++ b/server/package.json
@@ -12,8 +12,8 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    cors": "^2.8.5",
     "body-parser": "^2.2.0",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "stripe": "^18.5.0"
   }


### PR DESCRIPTION
## Summary
- permit requests from https://retotalai.vercel.app and local dev via CORS middleware
- install cors dependency for Express server

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94f17d3e48326bde7a9c1ab71a6ca