### PR TITLE
feat: allow vercel domain in cors

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,8 +32,8 @@ try {
 const app = express();
 app.use(cors({
   origin: [
-    "https://retotalai.vercel.app", // Vercel deployment URL
-    "http://localhost:3000"               // keep for safety; fine to leave
+    "https://r-etotal-ai-site.vercel.app", // live Vercel frontend
+    "http://localhost:3000"                // local dev
   ],
   credentials: false
 }));


### PR DESCRIPTION
## Summary
- allow production Vercel domain in CORS origin list

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bd001876408326ab5634e920771082