### PR TITLE
Fix server package.json syntax

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    cors": "^2.8.5",
+    "cors": "^2.8.5",
     "body-parser": "^2.2.0",
     "express": "^5.1.0",
     "stripe": "^18.5.0"


### PR DESCRIPTION
## Summary
- fix missing quote for cors dependency in server package.json

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda1c44f588326955ad5797a4c135a