### PR TITLE
chore: env-driven CORS and API base URL

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,37 @@
+name: Smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Validate package.json files
+        run: |
+          node -e "const fs=require('fs');const g=require('child_process').execSync('git ls-files \"**/package.json\"').toString().trim().split('\n').filter(Boolean);for(const f of g){JSON.parse(fs.readFileSync(f,'utf8'));};console.log('✅ all package.json valid');"
+
+      - name: Health check
+        run: |
+          set -e
+          code=$(curl -s -o /dev/null -w "%{http_code}" "${{ secrets.RENDER_API_URL }}/health")
+          echo "status=$code"
+          [ "$code" = "200" ] || (echo "::error::Health check failed" && exit 1)
+
+      - name: CORS preflight
+        run: |
+          set -e
+          headers=$(mktemp)
+          curl -s -D "$headers" -o /dev/null -X OPTIONS "${{ secrets.RENDER_API_URL }}/api/trial/start" \
+            -H "Origin: ${{ secrets.FRONTEND_ORIGIN }}" \
+            -H "Access-Control-Request-Method: POST"
+          origin=$(grep -i '^access-control-allow-origin:' "$headers" | awk '{print $2}' | tr -d '\r')
+          echo "allow-origin=$origin"
+          [ "$origin" = "${{ secrets.FRONTEND_ORIGIN }}" ] || (echo "::error::CORS allow-origin mismatch" && exit 1)

--- a/app/deals/page.tsx
+++ b/app/deals/page.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
+import { api } from '@/src/api';
 
 async function fetchDeals() {
-  const res = await fetch('/api/deals', { cache: 'no-store' });
-  return res.json();
+  return api('/api/deals', { cache: 'no-store' });
 }
 
 export default async function DealsPage() {

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState, useRef } from 'react';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
+import { api } from '@/src/api';
 
 export default function ShareView({ params }: { params: { token: string } }) {
   const [data, setData] = useState<any>(null);
@@ -9,8 +10,10 @@ export default function ShareView({ params }: { params: { token: string } }) {
 
   useEffect(() => {
     (async () => {
-      const res = await fetch(`/api/share/${params.token}`);
-      if (res.ok) setData(await res.json());
+        try {
+          const res = await api(`/api/share/${params.token}`);
+          setData(res);
+        } catch {}
     })();
   }, [params.token]);
 

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
+import { api } from '@/src/api';
 
 async function getHealth() {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/health`, { cache: 'no-store' });
-    if (!res.ok) {
-      throw new Error('Failed');
-    }
-    return res.json();
+    return await api('/health', { cache: 'no-store' });
   } catch {
     return { error: true } as const;
   }
@@ -14,11 +11,7 @@ async function getHealth() {
 
 async function getTrialStatus() {
   try {
-    const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/trial/status`, { cache: 'no-store' });
-    if (!res.ok) {
-      throw new Error('Failed');
-    }
-    return res.json();
+    return await api('/api/trial/status', { cache: 'no-store' });
   } catch {
     return { error: true } as const;
   }

--- a/app/tools/deal-analyzer/page.tsx
+++ b/app/tools/deal-analyzer/page.tsx
@@ -3,6 +3,7 @@ import { useState, useRef } from 'react';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 import { analyze, DealInputs } from '@/lib/deal/analyze';
+import { api } from '@/src/api';
 
 const money = (n: number) => `$${Number(n || 0).toLocaleString()}`;
 
@@ -34,30 +35,27 @@ export default function DealAnalyzerPage() {
   function calc() { setOut(analyze(state)); }
 
   async function saveAndShare() {
-    // 1) Create a deal
-    const create = await fetch('/api/deals', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        title: 'Analysis',
-        purchasePrice: state.purchasePrice,
-        rehabCost: state.rehabCost,
-        arv: state.arv
-      })
-    });
-    const { id } = await create.json();
+      // 1) Create a deal
+      const { id } = await api('/api/deals', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'Analysis',
+          purchasePrice: state.purchasePrice,
+          rehabCost: state.rehabCost,
+          arv: state.arv
+        })
+      });
 
-    // 2) Save run snapshot via analyze API
-    const run = await fetch(`/api/deals/${id}/analyze`, {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(state)
-    });
-    const outputs = await run.json();
-    setOut(outputs);
+      // 2) Save run snapshot via analyze API
+      const outputs = await api(`/api/deals/${id}/analyze`, {
+        method: 'POST',
+        body: JSON.stringify(state)
+      });
+      setOut(outputs);
 
-    // 3) Create/reuse share link
-    const resp = await fetch(`/api/deals/${id}/share`, { method: 'POST' });
-    const { url } = await resp.json();
-    setShareUrl(url);
+      // 3) Create/reuse share link
+      const { url } = await api(`/api/deals/${id}/share`, { method: 'POST' });
+      setShareUrl(url);
   }
 
   async function downloadPdf() {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "start": "next start",
     "test": "node tests/propertyValuation.test.mjs",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "health": "curl -i $RENDER_API_URL/health",
+    "preflight": "curl -i -X OPTIONS $RENDER_API_URL/api/trial/start -H \"Origin: $FRONTEND_ORIGIN\" -H \"Access-Control-Request-Method: POST\""
   },
   "keywords": [],
   "author": "REtotalAI Team",

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,10 @@
-        // Smooth scrolling
-        document.querySelectorAll('a[href^="#"]:not([data-open-auth]):not([data-open-login])').forEach(anchor => {
+         const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+         if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+             console.log('[API]', baseUrl);
+         }
+
+         // Smooth scrolling
+         document.querySelectorAll('a[href^="#"]:not([data-open-auth]):not([data-open-login])').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
                 e.preventDefault();
                 const target = document.querySelector(this.getAttribute('href'));
@@ -120,7 +125,7 @@
                 return;
             }
             try {
-                const res = await fetch('/api/signup', {
+                 const res = await fetch(`${baseUrl}/api/signup`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ name, email, password })
@@ -144,7 +149,7 @@
                 return;
             }
             try {
-                const res = await fetch('/api/login', {
+                 const res = await fetch(`${baseUrl}/api/login`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email, password })

--- a/server/index.js
+++ b/server/index.js
@@ -42,13 +42,14 @@ const ALLOWED_ORIGINS = Array.from(
   new Set([FRONTEND_URL, ...EXTRA_URLS, RENDER_URL, "http://localhost:3000"].filter(Boolean))
 );
 
-app.use(cors({
-  origin: (origin, cb) => {
-    if (!origin) return cb(null, true); // allow curl/postman
-    return cb(null, ALLOWED_ORIGINS.includes(origin));
-  },
-  credentials: false
-}));
+const corsOriginFn = (origin, cb) => {
+  if (!origin) return cb(null, true); // allow curl/postman
+  return cb(null, ALLOWED_ORIGINS.includes(origin));
+};
+
+app.use(cors({ origin: corsOriginFn, credentials: false }));
+// Handle preflight CORS for all routes
+app.options("*", cors({ origin: corsOriginFn, credentials: false }));
 
 const PORT = Number(process.env.PORT) || 4000;
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,8 @@
 // src/api.ts
-export const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+export const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
+if (process.env.NODE_ENV !== "production") {
+  console.log("[API]", baseUrl);
+}
 
 export async function api(path: string, init: RequestInit = {}) {
   const headers = new Headers(init.headers || {});
@@ -13,7 +16,7 @@ export async function api(path: string, init: RequestInit = {}) {
   }
   headers.set("x-user-id", "dev-user-1"); // temp dev identity
 
-  const res = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+  const res = await fetch(`${baseUrl}${path}`, { ...init, headers });
   if (res.status === 402) {
     const json = await res.json().catch(() => ({}));
     const err: any = new Error(json.message || "PAYWALL");


### PR DESCRIPTION
## Summary
- build Express CORS allowlist from env vars and log list on boot
- route all frontend API calls through NEXT_PUBLIC_API_URL-aware helper
- add CI smoke workflow and local health/preflight scripts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2856676c8326b684018879db41cd