### PR TITLE
fix(server): Express 5 path-to-regexp — replace '*' with '/*' for preflight

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -48,8 +48,12 @@ const corsOriginFn = (origin, cb) => {
 };
 
 app.use(cors({ origin: corsOriginFn, credentials: false }));
-// Handle preflight CORS for all routes
-app.options("*", cors({ origin: corsOriginFn, credentials: false }));
+// Handle preflight CORS for all routes (Express 5: '*' is invalid; use '/*' or a RegExp)
+app.options("/*", cors({
+  origin: corsOriginFn,
+  credentials: false,
+  optionsSuccessStatus: 204
+}));
 
 const PORT = Number(process.env.PORT) || 4000;
 


### PR DESCRIPTION
## Summary
- update CORS preflight route to use valid Express 5 pattern

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be2bc4ab448326b24c5aa16fecf820