### PR TITLE
fix(server): CORS allow previews (*.vercel.app) + deny log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,15 @@ const ALLOWED_ORIGINS = Array.from(
 
 const corsOriginFn = (origin, cb) => {
   if (!origin) return cb(null, true); // allow curl/postman/no-origin
-  return cb(null, ALLOWED_ORIGINS.includes(origin));
+  // Exact allowlist hit
+  if (ALLOWED_ORIGINS.includes(origin)) return cb(null, true);
+  // Allow Vercel preview/prod subdomains
+  try {
+    const { hostname } = new URL(origin);
+    if (hostname.endsWith(".vercel.app")) return cb(null, true);
+  } catch {}
+  console.warn("[CORS] denied origin:", origin, "allowed:", ALLOWED_ORIGINS);
+  return cb(null, false);
 };
 
 // Main CORS middleware


### PR DESCRIPTION
## Summary
- expand CORS origin function to allow any `.vercel.app` origin for preview deployments
- log denied origins when not matched by env allowlist or vercel preview domains

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68be321218f48326b4b766b7ae9b3f2b