### PR TITLE
fix(server): isAllowedOrigin should return boolean

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,17 +42,20 @@ const ALLOWED_ORIGINS = Array.from(
   new Set([FRONTEND_URL, ...EXTRA_URLS, RENDER_URL, "http://localhost:3000"].filter(Boolean))
 );
 
-const corsOriginFn = (origin, cb) => {
-  if (!origin) return cb(null, true); // allow curl/postman/no-origin
-  // Exact allowlist hit
-  if (ALLOWED_ORIGINS.includes(origin)) return cb(null, true);
-  // Allow Vercel preview/prod subdomains
+const isAllowedOrigin = (origin) => {
+  if (!origin) return true; // non-browser tools
+  if (ALLOWED_ORIGINS.includes(origin)) return true;
   try {
     const { hostname } = new URL(origin);
-    if (hostname.endsWith(".vercel.app")) return cb(null, true);
+    if (hostname.endsWith(".vercel.app")) return true;
   } catch {}
-  console.warn("[CORS] denied origin:", origin, "allowed:", ALLOWED_ORIGINS);
-  return cb(null, false);
+  return false;
+};
+
+const corsOriginFn = (origin, cb) => {
+  const ok = isAllowedOrigin(origin);
+  if (!ok) console.warn("[CORS] denied origin:", origin, "allowed:", ALLOWED_ORIGINS);
+  return cb(null, ok);
 };
 
 // Main CORS middleware


### PR DESCRIPTION
## Summary
- refactor CORS origin check to boolean helper `isAllowedOrigin`

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `curl -i -X OPTIONS https://retotalai-site.onrender.com/api/trial/start -H "Origin: https://r-etotal-ai-site.vercel.app" -H "Access-Control-Request-Method: POST"` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf13970c4c8326bab4d72db5e8a4eb