### PR TITLE
Add deal test scripts and recent-deals endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,31 @@ Run static analysis before committing changes:
 npm run lint       # ESLint for code quality
 npm run type-check # TypeScript type checking
 ```
+
+## End-to-end Deal Tests
+
+We include simple E2E tests that post realistic deals and open the generated PDFs.
+
+### macOS / Linux
+```bash
+SERVICE=https://retotalai-site.onrender.com \
+./scripts/run_deal_tests.sh
+```
+Requires `jq` and `curl`.
+
+### Windows (PowerShell)
+```powershell
+$env:SERVICE="https://retotalai-site.onrender.com"
+./scripts/run_deal_tests.ps1
+```
+
+### Postman
+Import `postman/REtotalAi_Deal_Tests.postman_collection.json`, set:
+- `baseUrl = https://retotalai-site.onrender.com`
+- `origin  = https://r-etotal-ai-site.vercel.app`
+
+### Recent deals helper
+List the latest deals to click their PDFs:
+```
+GET /api/deals/recent?limit=10
+```

--- a/postman/REtotalAi_Deal_Tests.postman_collection.json
+++ b/postman/REtotalAi_Deal_Tests.postman_collection.json
@@ -1,0 +1,82 @@
+{
+  "info": { "name": "REtotalAi Deal Tests", "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json" },
+  "item": [
+    {
+      "name": "1) Rental — baseline",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"123 Oak Lane, Dallas, TX\",\"type\":\"Single Family\"},\"numbers\":{\"purchase\":150000,\"arv\":160000,\"rehab\":10000,\"rent\":1300,\"taxes\":2500,\"insurance\":900,\"hoa\":0,\"vacancyPct\":5,\"maintenancePct\":5,\"managementPct\":8,\"otherMonthly\":25,\"downPct\":20,\"ratePct\":7.0,\"termYears\":30}}" }
+      }
+    },
+    {
+      "name": "2) Rental — stronger",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"742 Evergreen Terrace, Springfield, USA\",\"type\":\"Single Family\"},\"numbers\":{\"purchase\":180000,\"arv\":220000,\"rehab\":15000,\"rent\":1950,\"taxes\":3600,\"insurance\":1200,\"hoa\":0,\"vacancyPct\":5,\"maintenancePct\":5,\"managementPct\":8,\"otherMonthly\":50,\"downPct\":20,\"ratePct\":7.0,\"termYears\":30}}" }
+      }
+    },
+    {
+      "name": "3) Flip — negative margin",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"456 Maple St, Atlanta, GA\",\"type\":\"Fix & Flip\"},\"numbers\":{\"purchase\":220000,\"arv\":320000,\"rehab\":60000,\"downPct\":15,\"ratePct\":8.5,\"holdingMonths\":6,\"carryOtherMonthly\":200,\"sellingCostPct\":8,\"closingCostPct\":2}}" }
+      }
+    },
+    {
+      "name": "4) Flip — profitable",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"456 Maple St, Atlanta, GA\",\"type\":\"Fix & Flip\"},\"numbers\":{\"purchase\":220000,\"arv\":360000,\"rehab\":60000,\"downPct\":15,\"ratePct\":8.5,\"holdingMonths\":6,\"carryOtherMonthly\":200,\"sellingCostPct\":8,\"closingCostPct\":2}}" }
+      }
+    },
+    {
+      "name": "5) Pagination stress",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"999 Long Report Way, Phoenix, AZ\",\"type\":\"Single Family\"},\"numbers\":{\"purchase\":275000,\"arv\":375000,\"rehab\":65000,\"rent\":2600,\"taxes\":6200,\"insurance\":1800,\"hoa\":150,\"vacancyPct\":7,\"maintenancePct\":8,\"managementPct\":9,\"otherMonthly\":100,\"downPct\":20,\"ratePct\":7.25,\"termYears\":30,\"holdingMonths\":7,\"carryOtherMonthly\":250,\"sellingCostPct\":8,\"closingCostPct\":2}}" }
+      }
+    },
+    {
+      "name": "6) Flip only — no rent",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "Origin", "value": "{{origin}}" }
+        ],
+        "url": { "raw": "{{baseUrl}}/api/deals", "host": ["{{baseUrl}}"], "path": ["api","deals"] },
+        "body": { "mode": "raw", "raw": "{\"property\":{\"address\":\"No Rent Test, Miami, FL\",\"type\":\"Condo\"},\"numbers\":{\"purchase\":300000,\"arv\":360000,\"rehab\":40000,\"downPct\":20,\"ratePct\":7.0,\"termYears\":30,\"holdingMonths\":6,\"sellingCostPct\":7,\"closingCostPct\":2}}" }
+      }
+    }
+  ],
+  "variable": [
+    { "key": "baseUrl", "value": "https://retotalai-site.onrender.com" },
+    { "key": "origin",  "value": "https://r-etotal-ai-site.vercel.app" }
+  ]
+}
+

--- a/scripts/run_deal_tests.ps1
+++ b/scripts/run_deal_tests.ps1
@@ -1,0 +1,50 @@
+Param(
+  [string]$Service = "https://retotalai-site.onrender.com"
+)
+$headers = @{ "Content-Type" = "application/json"; "Origin" = "https://r-etotal-ai-site.vercel.app" }
+
+Function Post-Deal($body) {
+  $json = $body | ConvertTo-Json -Depth 6
+  $resp = Invoke-RestMethod -Method Post -Uri "$Service/api/deals" -Headers $headers -Body $json
+  return $resp.id
+}
+Function Open-Pdf($id) {
+  Start-Process "$Service/api/deals/$id/report"
+}
+
+Write-Host "Running tests against: $Service"
+Write-Host "===================================================="
+
+$id1 = Post-Deal @{
+  property = @{ address="123 Oak Lane, Dallas, TX"; type="Single Family" }
+  numbers = @{ purchase=150000; arv=160000; rehab=10000; rent=1300; taxes=2500; insurance=900; hoa=0; vacancyPct=5; maintenancePct=5; managementPct=8; otherMonthly=25; downPct=20; ratePct=7.0; termYears=30 }
+}; Write-Host "[1] Deal ID: $id1"; Open-Pdf $id1
+
+$id2 = Post-Deal @{
+  property = @{ address="742 Evergreen Terrace, Springfield, USA"; type="Single Family" }
+  numbers = @{ purchase=180000; arv=220000; rehab=15000; rent=1950; taxes=3600; insurance=1200; hoa=0; vacancyPct=5; maintenancePct=5; managementPct=8; otherMonthly=50; downPct=20; ratePct=7.0; termYears=30 }
+}; Write-Host "[2] Deal ID: $id2"; Open-Pdf $id2
+
+$id3 = Post-Deal @{
+  property = @{ address="456 Maple St, Atlanta, GA"; type="Fix & Flip" }
+  numbers = @{ purchase=220000; arv=320000; rehab=60000; downPct=15; ratePct=8.5; holdingMonths=6; carryOtherMonthly=200; sellingCostPct=8; closingCostPct=2 }
+}; Write-Host "[3] Deal ID: $id3"; Open-Pdf $id3
+
+$id4 = Post-Deal @{
+  property = @{ address="456 Maple St, Atlanta, GA"; type="Fix & Flip" }
+  numbers = @{ purchase=220000; arv=360000; rehab=60000; downPct=15; ratePct=8.5; holdingMonths=6; carryOtherMonthly=200; sellingCostPct=8; closingCostPct=2 }
+}; Write-Host "[4] Deal ID: $id4"; Open-Pdf $id4
+
+$id5 = Post-Deal @{
+  property = @{ address="999 Long Report Way, Phoenix, AZ"; type="Single Family" }
+  numbers = @{ purchase=275000; arv=375000; rehab=65000; rent=2600; taxes=6200; insurance=1800; hoa=150; vacancyPct=7; maintenancePct=8; managementPct=9; otherMonthly=100; downPct=20; ratePct=7.25; termYears=30; holdingMonths=7; carryOtherMonthly=250; sellingCostPct=8; closingCostPct=2 }
+}; Write-Host "[5] Deal ID: $id5"; Open-Pdf $id5
+
+$id6 = Post-Deal @{
+  property = @{ address="No Rent Test, Miami, FL"; type="Condo" }
+  numbers = @{ purchase=300000; arv=360000; rehab=40000; downPct=20; ratePct=7.0; termYears=30; holdingMonths=6; sellingCostPct=7; closingCostPct=2 }
+}; Write-Host "[6] Deal ID: $id6"; Open-Pdf $id6
+
+Write-Host "===================================================="
+Write-Host "All tests posted. PDFs opened."
+

--- a/scripts/run_deal_tests.sh
+++ b/scripts/run_deal_tests.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   chmod +x scripts/run_deal_tests.sh
+#   SERVICE=https://retotalai-site.onrender.com ./scripts/run_deal_tests.sh
+#
+# Requires: jq, curl
+
+SERVICE="${SERVICE:-https://retotalai-site.onrender.com}"
+HDR_CONTENT='Content-Type: application/json'
+ORIGIN='Origin: https://r-etotal-ai-site.vercel.app'
+
+opener() {
+  if command -v open >/dev/null 2>&1; then open "$1";
+  elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$1";
+  else echo "Open this in a browser: $1"; fi
+}
+
+post_deal() {
+  local body="$1"
+  curl -s -X POST "$SERVICE/api/deals" -H "$HDR_CONTENT" -H "$ORIGIN" -d "$body" | jq -r .id
+}
+
+echo "Running tests against: $SERVICE"
+echo "===================================================="
+
+echo "[1] Rental — baseline"
+ID1=$(post_deal '{
+  "property": { "address": "123 Oak Lane, Dallas, TX", "type": "Single Family" },
+  "numbers": {
+    "purchase": 150000, "arv": 160000, "rehab": 10000, "rent": 1300,
+    "taxes": 2500, "insurance": 900, "hoa": 0,
+    "vacancyPct": 5, "maintenancePct": 5, "managementPct": 8, "otherMonthly": 25,
+    "downPct": 20, "ratePct": 7.0, "termYears": 30
+  }
+}')
+echo "Deal ID: $ID1"
+opener "$SERVICE/api/deals/$ID1/report"
+
+echo "[2] Rental — stronger"
+ID2=$(post_deal '{
+  "property": { "address": "742 Evergreen Terrace, Springfield, USA", "type": "Single Family" },
+  "numbers": {
+    "purchase": 180000, "arv": 220000, "rehab": 15000, "rent": 1950,
+    "taxes": 3600, "insurance": 1200, "hoa": 0,
+    "vacancyPct": 5, "maintenancePct": 5, "managementPct": 8, "otherMonthly": 50,
+    "downPct": 20, "ratePct": 7.0, "termYears": 30
+  }
+}')
+echo "Deal ID: $ID2"
+opener "$SERVICE/api/deals/$ID2/report"
+
+echo "[3] Flip — negative margin"
+ID3=$(post_deal '{
+  "property": { "address": "456 Maple St, Atlanta, GA", "type": "Fix & Flip" },
+  "numbers": {
+    "purchase": 220000, "arv": 320000, "rehab": 60000,
+    "downPct": 15, "ratePct": 8.5,
+    "holdingMonths": 6, "carryOtherMonthly": 200,
+    "sellingCostPct": 8, "closingCostPct": 2
+  }
+}')
+echo "Deal ID: $ID3"
+opener "$SERVICE/api/deals/$ID3/report"
+
+echo "[4] Flip — profitable"
+ID4=$(post_deal '{
+  "property": { "address": "456 Maple St, Atlanta, GA", "type": "Fix & Flip" },
+  "numbers": {
+    "purchase": 220000, "arv": 360000, "rehab": 60000,
+    "downPct": 15, "ratePct": 8.5,
+    "holdingMonths": 6, "carryOtherMonthly": 200,
+    "sellingCostPct": 8, "closingCostPct": 2
+  }
+}')
+echo "Deal ID: $ID4"
+opener "$SERVICE/api/deals/$ID4/report"
+
+echo "[5] Pagination stress"
+ID5=$(post_deal '{
+  "property": { "address": "999 Long Report Way, Phoenix, AZ", "type": "Single Family" },
+  "numbers": {
+    "purchase": 275000, "arv": 375000, "rehab": 65000, "rent": 2600,
+    "taxes": 6200, "insurance": 1800, "hoa": 150,
+    "vacancyPct": 7, "maintenancePct": 8, "managementPct": 9, "otherMonthly": 100,
+    "downPct": 20, "ratePct": 7.25, "termYears": 30,
+    "holdingMonths": 7, "carryOtherMonthly": 250,
+    "sellingCostPct": 8, "closingCostPct": 2
+  }
+}')
+echo "Deal ID: $ID5"
+opener "$SERVICE/api/deals/$ID5/report"
+
+echo "[6] Flip only — no rent"
+ID6=$(post_deal '{
+  "property": { "address": "No Rent Test, Miami, FL", "type": "Condo" },
+  "numbers": {
+    "purchase": 300000, "arv": 360000, "rehab": 40000,
+    "downPct": 20, "ratePct": 7.0, "termYears": 30,
+    "holdingMonths": 6, "sellingCostPct": 7, "closingCostPct": 2
+  }
+}')
+echo "Deal ID: $ID6"
+opener "$SERVICE/api/deals/$ID6/report"
+
+echo "===================================================="
+echo "All tests posted. Opened PDFs (use browser/system viewer)."
+

--- a/server/index.js
+++ b/server/index.js
@@ -430,6 +430,22 @@ app.get("/api/ping", (_req, res) => {
   res.json({ ok: true, time: new Date().toISOString() });
 });
 
+// List recent deals for test convenience
+// GET /api/deals/recent?limit=10
+app.get("/api/deals/recent", (req, res) => {
+  const lim = Math.max(1, Math.min(100, Number(req.query.limit) || 10));
+  const items = [...db.deals.values()]
+    .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
+    .slice(0, lim)
+    .map(d => ({
+      id: d.id,
+      address: d.property?.address || null,
+      type: d.property?.type || null,
+      createdAt: d.createdAt
+    }));
+  res.json({ deals: items });
+});
+
 // Friendly landing page for the API root (safe, noindex, no-store)
 app.get("/", (_req, res) => {
   res.setHeader("Content-Type", "text/html; charset=utf-8");

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index.js",
+    "e2e:deals": "bash ./scripts/run_deal_tests.sh"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `/api/deals/recent` endpoint to fetch latest deals
- provide cross-platform scripts and Postman collection for posting sample deals
- document end-to-end test workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c2605412cc8326b9f45011c175261e