### PR TITLE
feat(compare): implement full compare feature

### DIFF
--- a/app/api/deals/compare/report/route.ts
+++ b/app/api/deals/compare/report/route.ts
@@ -1,0 +1,39 @@
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const maxDuration = 60;
+
+import { NextResponse } from "next/server";
+import { renderCompareReportHTML } from "@/lib/report/CompareReportTemplate";
+import chromium from "@sparticuz/chromium";
+import puppeteer from "puppeteer-core";
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const ids = (url.searchParams.get("ids") ?? "").split(",").filter(Boolean);
+  const mode = url.searchParams.get("mode") ?? "Balanced";
+
+  const origin = process.env.SITE_URL || url.origin;
+  const deals = await Promise.all(
+    ids.map(id => fetch(`${origin}/api/deals/${id}`, { cache: "no-store" }).then(r=>r.json()))
+  );
+
+  const html = renderCompareReportHTML({ deals, mode });
+
+  const browser = await puppeteer.launch({
+    args: chromium.args,
+    executablePath: await chromium.executablePath(),
+    headless: true
+  });
+  const page = await browser.newPage();
+  await page.setContent(html, { waitUntil: "networkidle0" });
+  const pdf = await page.pdf({ format:"Letter", printBackground:true, margin:{ top:"0.5in", right:"0.5in", bottom:"0.6in", left:"0.5in" } });
+  await browser.close();
+
+  return new NextResponse(Buffer.from(pdf), {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": "inline; filename=compare.pdf",
+    },
+  });
+}

--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -1,0 +1,191 @@
+"use client";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import { useCompareSet } from "@/lib/compare/compareStore";
+import { CompareToolbar, KpiKey } from "@/components/compare/CompareToolbar";
+import { CompareTable, CompareRow } from "@/components/compare/CompareTable";
+import { CompareCharts } from "@/components/compare/CompareCharts";
+import { CalcPresets } from "@/lib/calc/presets";
+import type { CalcBases } from "@/lib/calc/types";
+import { compositeScore } from "@/lib/compare/score";
+
+export default function CompareClient() {
+  const sp = useSearchParams();
+  const queryKey = sp ? sp.toString() : "";
+  const router = useRouter();
+  const { ids, add, remove, clear } = useCompareSet();
+  const [presetId, setPresetId] = useState(CalcPresets[0].id);
+  const [bases, setBases] = useState<CalcBases>(CalcPresets[0].bases);
+  const [kpis, setKpis] = useState<KpiKey[]>(["cap","dscr","cf","profit"]);
+  const [sortBy, setSortBy] = useState<KpiKey>("cap");
+  const [sortDir, setSortDir] = useState<"asc"|"desc">("desc");
+  const [filters, setFilters] = useState<any>({});
+  const [weights, setWeights] = useState({ dscr:40, cap:30, cf:20, profit:10 });
+  const [deals, setDeals] = useState<any[]>([]);
+
+  useEffect(()=>{
+    const params = new URLSearchParams(queryKey);
+    const qIds = (params.get("ids")||"").split(",").filter(Boolean);
+    qIds.forEach(add);
+    const mode = params.get("mode");
+    if(mode) setPresetId(mode);
+    const k = params.get("kpis");
+    if(k) setKpis(k.split(",") as KpiKey[]);
+  },[queryKey, add]);
+
+  useEffect(()=>{
+    if(!ids.length){ setDeals([]); return; }
+    const ac = new AbortController();
+    Promise.all(
+      ids.map(id =>
+        fetch(`/api/deals/${id}`, { cache: "no-store", signal: ac.signal })
+          .then(r => r.json())
+          .catch(() => null)
+      )
+    )
+      .then(setDeals)
+      .catch(e => { if(e.name !== "AbortError") console.error(e); });
+    return () => ac.abort();
+  },[ids]);
+
+  const rows: CompareRow[] = useMemo(() => {
+    const calc = (deal: any): CompareRow => {
+      const n = deal.numbers || {};
+      const address = deal.property?.address || deal.title || deal.id;
+      const purchase = +n.purchasePrice || +n.purchase || 0;
+      const rehab = +n.rehabCost || +n.rehab || 0;
+      const arv = +n.arv || 0;
+      const rent = +n.rent || 0;
+      const taxes = +n.taxes || 0;
+      const insurance = +n.insurance || 0;
+      const hoa = +n.hoa || 0;
+      const vacancyPct = +n.vacancyPct || 0;
+      const maintenancePct = +n.maintenancePct || 0;
+      const managementPct = +n.managementPct || 0;
+      const otherMonthly = +n.otherMonthly || 0;
+      const downPct = +n.downPct || 0;
+      const ratePct = +n.ratePct || 0;
+      const termYears = +n.termYears || 0;
+      const grossAnnual = rent * 12;
+      const vac = grossAnnual * (vacancyPct / 100);
+      const percentBase = bases.percentBasis === "egi" ? grossAnnual - vac : grossAnnual;
+      const maint = percentBase * (maintenancePct / 100);
+      const mgmt = percentBase * (managementPct / 100);
+      const opEx = taxes + insurance + hoa * 12 + vac + maint + mgmt + otherMonthly * 12;
+      const noi = grossAnnual - opEx;
+      const allIn = purchase + rehab;
+      const capDenom = bases.capBasis === "purchase" ? purchase : allIn;
+      const capRate = capDenom > 0 ? noi / capDenom : undefined;
+      const loanBase = bases.loanBasis === "purchase" ? purchase : allIn;
+      const down = loanBase * (downPct / 100);
+      const loanAmt = Math.max(loanBase - down, 0);
+      const r = (ratePct / 100) / 12;
+      const nPmts = termYears * 12;
+      const monthlyPI = loanAmt > 0 && r > 0 && nPmts > 0 ? (loanAmt * r) / (1 - Math.pow(1 + r, -nPmts)) : 0;
+      const annualDebt = monthlyPI * 12;
+      const dscr = annualDebt > 0 ? noi / annualDebt : undefined;
+      const annualCF = noi - annualDebt;
+      let invested = down;
+      if (bases.investedBasis !== "down") invested += rehab;
+      const coc = invested > 0 ? annualCF / invested : undefined;
+      const grm = grossAnnual > 0 ? allIn / grossAnnual : undefined;
+      const grossYield = allIn > 0 ? grossAnnual / allIn : undefined;
+      const oer = grossAnnual > 0 ? opEx / grossAnnual : undefined;
+      const holdingMonths = +n.holdingMonths || +n.monthsToComplete || 0;
+      const sellingPct = (+n.sellingCostPct || 0) + (+n.closingCostPct || 0);
+      const carryOtherMonthly = +n.carryOtherMonthly || 0;
+      const carrying = (taxes / 12 + insurance / 12 + hoa + carryOtherMonthly) * holdingMonths;
+      const selling = arv * (sellingPct / 100);
+      const totalInvest = purchase + rehab + carrying + selling;
+      const profit = arv - totalInvest;
+      const margin = arv > 0 ? profit / arv : undefined;
+      const em = totalInvest > 0 ? arv / totalInvest : undefined;
+      const flags: string[] = [];
+      if (dscr !== undefined && dscr < 1) flags.push("Debt shortfall");
+      if (capRate !== undefined && capRate < 0.06) flags.push("Low cap");
+      if (annualCF < 0) flags.push("Negative CF");
+      if (margin !== undefined && margin < 0.05) flags.push("Thin margin");
+      return {
+        id: deal.id,
+        address,
+        strategy: [deal.mode || ""],
+        values: { cap: capRate, dscr, cf: annualCF, coc, grm, yield: grossYield, oer, profit, margin, em },
+        score: 0,
+        flags,
+      };
+    };
+    const prelim = deals.filter(Boolean).map(calc);
+    const ranges = {
+      dscr: [Math.min(...prelim.map(r => r.values.dscr || 0)), Math.max(...prelim.map(r => r.values.dscr || 0))] as [number, number],
+      cap: [Math.min(...prelim.map(r => r.values.cap || 0)), Math.max(...prelim.map(r => r.values.cap || 0))] as [number, number],
+      cf: [Math.min(...prelim.map(r => r.values.cf || 0)), Math.max(...prelim.map(r => r.values.cf || 0))] as [number, number],
+      profit: [Math.min(...prelim.map(r => r.values.profit || 0)), Math.max(...prelim.map(r => r.values.profit || 0))] as [number, number],
+    };
+    const scored = prelim.map(r => ({
+      ...r,
+      score: compositeScore(
+        { dscr: r.values.dscr, capRate: r.values.cap, annualCF: r.values.cf, profit: r.values.profit },
+        weights,
+        ranges,
+      ),
+    }));
+    return scored
+      .filter(
+        r =>
+          (filters.dscrMin == null || (r.values.dscr ?? 0) >= filters.dscrMin) &&
+          (filters.capMin == null || (r.values.cap ?? 0) >= filters.capMin / 100) &&
+          (filters.cfMin == null || (r.values.cf ?? 0) >= filters.cfMin) &&
+          (filters.profitMin == null || (r.values.profit ?? 0) >= filters.profitMin),
+      )
+      .sort((a, b) => {
+        const va = a.values[sortBy] ?? 0;
+        const vb = b.values[sortBy] ?? 0;
+        return sortDir === "asc" ? va - vb : vb - va;
+      });
+  }, [deals, bases, filters, sortBy, sortDir, weights]);
+
+  const points = rows.map(r=>({ x:r.values.dscr||0, y:(r.values.cap||0)*100, size:r.values.cf||0, label:r.address.split(',')[0]}));
+
+  const handleShare = ()=>{
+    const url = new URL(window.location.href);
+    url.searchParams.set('ids', ids.join(','));
+    url.searchParams.set('mode', presetId);
+    url.searchParams.set('kpis', kpis.join(','));
+    router.replace(url.pathname + '?' + url.searchParams.toString());
+    navigator.clipboard.writeText(url.toString());
+  };
+
+  const handleExport = ()=>{
+    const url = `/api/deals/compare/report?ids=${ids.join(',')}&mode=${presetId}&kpis=${kpis.join(',')}`;
+    window.open(url, '_blank');
+  };
+
+  return (
+    <main className="p-4 space-y-4">
+      <CompareToolbar
+        presetId={presetId}
+        bases={bases}
+        kpis={kpis}
+        sortBy={sortBy}
+        sortDir={sortDir}
+        filters={filters}
+        weights={weights}
+        onPreset={id => {
+          setPresetId(id);
+          const preset = CalcPresets.find(p => p.id === id);
+          if (preset) setBases(preset.bases);
+        }}
+        onBases={setBases}
+        onKpis={setKpis}
+        onSort={(k,dir)=>{setSortBy(k); setSortDir(dir);}}
+        onFilters={setFilters}
+        onWeights={setWeights}
+        onShare={handleShare}
+        onExport={handleExport}
+        onClear={clear}
+      />
+      <CompareTable rows={rows} kpis={kpis} onRemove={remove} />
+      {rows.length ? <CompareCharts points={points} /> : null}
+    </main>
+  );
+}

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import CompareClient from "./CompareClient";
+
+export const metadata: Metadata = {
+  title: "Deal Comparison • REtotalAi",
+  description: "Compare rental/BRRRR/flip deals with DSCR, Cap, CF, Profit.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default function ComparePage() {
+  return <CompareClient />;
+}

--- a/app/deals/page.tsx
+++ b/app/deals/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { api } from '@/lib/api';
+import { AddToCompareButton } from '@/components/compare/AddToCompareButton';
 
 async function fetchDeals() {
   return api('/api/deals', { cache: 'no-store' });
@@ -19,7 +20,10 @@ export default async function DealsPage() {
                 {`Purchase $${Number(d.purchasePrice).toLocaleString()} · Rehab $${Number(d.rehabCost).toLocaleString()} · ARV $${Number(d.arv ?? 0).toLocaleString()}`}
               </div>
             </div>
-            <Link href={`/tools/deal-analyzer?id=${d.id}`} className="px-4 py-2 rounded-lg border">Open</Link>
+            <div className="flex items-center gap-3">
+              <AddToCompareButton dealId={d.id} />
+              <Link href={`/tools/deal-analyzer?id=${d.id}`} className="px-4 py-2 rounded-lg border">Open</Link>
+            </div>
           </div>
         ))}
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -188,6 +188,7 @@ export default function REtotalAiLandingPricing() {
             <a href="#features" className="hover:text-gray-900">Features</a>
             <a href="#pricing" className="hover:text-gray-900">Pricing</a>
             <a href="#how" className="hover:text-gray-900">How it works</a>
+            <a href="/compare" className="hover:text-gray-900">Compare</a>
           </nav>
           <div className="flex items-center gap-3">
             {trial.active && trial.endsAt ? (

--- a/app/tools/deal-analyzer/page.tsx
+++ b/app/tools/deal-analyzer/page.tsx
@@ -1,13 +1,21 @@
 'use client';
-import { useState, useRef, FormEvent } from 'react';
+import { useState, useRef, FormEvent, useEffect } from 'react';
 import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 import { analyze, DealInputs } from '@/lib/deal/analyze';
 import { api } from '@/lib/api';
+import { AddToCompareButton } from '@/components/compare/AddToCompareButton';
 
 const money = (n: number) => `$${Number(n || 0).toLocaleString()}`;
 
+export const dynamic = "force-dynamic";
+
 export default function DealAnalyzerPage() {
+  const [dealId, setDealId] = useState('');
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search);
+    setDealId(sp.get('id') || '');
+  }, []);
   const [mode] = useState<'flip'|'buyhold'|'brrrr'>('flip'); // tabs can be added
   const [state, setState] = useState<DealInputs>({
     mode: 'flip',
@@ -82,7 +90,10 @@ export default function DealAnalyzerPage() {
   return (
     <form onSubmit={handleGenerate} className="min-h-[100dvh] flex flex-col">
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8 pb-28 flex-1">
-        <h1 className="text-2xl font-semibold mb-4">Deal Analyzer — {mode === 'flip' ? 'Fix & Flip' : mode}</h1>
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-2xl font-semibold">Deal Analyzer — {mode === 'flip' ? 'Fix & Flip' : mode}</h1>
+          {dealId ? <AddToCompareButton dealId={dealId} /> : null}
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {/* LEFT: Inputs */}
           <div className="space-y-4">

--- a/lib/calc/presets.ts
+++ b/lib/calc/presets.ts
@@ -1,0 +1,23 @@
+import type { CalcModePreset } from './types';
+
+export const CalcPresets: CalcModePreset[] = [
+  {
+    id: 'Balanced',
+    bases: {
+      loanBasis: 'purchase',
+      percentBasis: 'gross',
+      capBasis: 'purchase',
+      investedBasis: 'down_plus_rehab',
+    },
+  },
+  {
+    id: 'Aggressive',
+    bases: {
+      loanBasis: 'all_in',
+      percentBasis: 'egi',
+      capBasis: 'all_in',
+      investedBasis: 'down_plus_rehab_closing',
+    },
+  },
+];
+

--- a/lib/calc/types.ts
+++ b/lib/calc/types.ts
@@ -1,0 +1,16 @@
+export type LoanBasis = "purchase" | "all_in";
+export type PercentBasis = "gross" | "egi";
+export type CapBasis = "purchase" | "all_in";
+export type InvestedBasis = "down" | "down_plus_rehab" | "down_plus_rehab_closing";
+
+export interface CalcBases {
+  loanBasis: LoanBasis;
+  percentBasis: PercentBasis;
+  capBasis: CapBasis;
+  investedBasis: InvestedBasis;
+}
+
+export interface CalcModePreset {
+  id: string;
+  bases: CalcBases;
+}

--- a/lib/compare/columns.ts
+++ b/lib/compare/columns.ts
@@ -1,0 +1,34 @@
+export interface KPIColumn {
+  key: string;
+  label: string;
+  formatter?: (value: number) => string;
+  align?: "left" | "right" | "center";
+  tooltip?: (value: number) => string;
+}
+
+export const DEFAULT_KPI_COLUMNS: KPIColumn[] = [
+  {
+    key: "capRate",
+    label: "Cap Rate",
+    formatter: (v) => `${(v * 100).toFixed(2)}%`,
+    align: "right",
+  },
+  {
+    key: "dscr",
+    label: "DSCR",
+    formatter: (v) => v.toFixed(2),
+    align: "right",
+  },
+  {
+    key: "annualCF",
+    label: "Annual CF",
+    formatter: (v) => v.toLocaleString(),
+    align: "right",
+  },
+  {
+    key: "profit",
+    label: "Profit",
+    formatter: (v) => v.toLocaleString(),
+    align: "right",
+  },
+];

--- a/lib/compare/compareStore.ts
+++ b/lib/compare/compareStore.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+const KEY = "compare:set:v1";
+
+export function useCompareSet() {
+  const [ids, setIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(KEY);
+      if (raw) setIds(JSON.parse(raw));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(ids));
+    } catch {
+      // ignore
+    }
+  }, [ids]);
+
+  const add = (id: string) =>
+    setIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  const remove = (id: string) =>
+    setIds((prev) => prev.filter((x) => x !== id));
+  const clear = () => setIds([]);
+
+  return { ids, add, remove, clear };
+}

--- a/lib/compare/score.ts
+++ b/lib/compare/score.ts
@@ -1,0 +1,37 @@
+export interface ScoreWeights {
+  dscr: number;
+  cap: number;
+  cf: number;
+  profit: number;
+}
+
+export interface ScoreInputs {
+  dscr?: number;
+  capRate?: number;
+  annualCF?: number;
+  profit?: number;
+}
+
+export function normalize(val: number | undefined, min: number, max: number) {
+  if (val === undefined || Number.isNaN(val)) return 0;
+  if (max === min) return 0;
+  return Math.max(0, Math.min(1, (val - min) / (max - min)));
+}
+
+export function compositeScore(
+  inp: ScoreInputs,
+  w: ScoreWeights,
+  ranges: {
+    dscr: [number, number];
+    cap: [number, number];
+    cf: [number, number];
+    profit: [number, number];
+  }
+) {
+  const sDSCR = normalize(inp.dscr, ranges.dscr[0], ranges.dscr[1]) * w.dscr;
+  const sCap = normalize(inp.capRate, ranges.cap[0], ranges.cap[1]) * w.cap;
+  const sCF = normalize(inp.annualCF, ranges.cf[0], ranges.cf[1]) * w.cf;
+  const sPft = normalize(inp.profit, ranges.profit[0], ranges.profit[1]) * w.profit;
+  const sumW = w.dscr + w.cap + w.cf + w.profit || 1;
+  return (sDSCR + sCap + sCF + sPft) / sumW;
+}

--- a/lib/report/CompareReportTemplate.ts
+++ b/lib/report/CompareReportTemplate.ts
@@ -1,0 +1,85 @@
+// @server-only
+/* eslint-disable @next/next/no-head-element */
+import { DEFAULT_KPI_COLUMNS } from "@/lib/compare/columns";
+import { compositeScore } from "@/lib/compare/score";
+
+function compute(deal: any) {
+  const n = deal.numbers || {};
+  const purchase = +n.purchasePrice || +n.purchase || 0;
+  const rehab = +n.rehabCost || +n.rehab || 0;
+  const arv = +n.arv || 0;
+  const rent = +n.rent || 0;
+  const taxes = +n.taxes || 0;
+  const insurance = +n.insurance || 0;
+  const hoa = +n.hoa || 0;
+  const vacancyPct = +n.vacancyPct || 0;
+  const maintenancePct = +n.maintenancePct || 0;
+  const managementPct = +n.managementPct || 0;
+  const otherMonthly = +n.otherMonthly || 0;
+  const downPct = +n.downPct || 0;
+  const ratePct = +n.ratePct || 0;
+  const termYears = +n.termYears || 0;
+  const grossAnnual = rent * 12;
+  const vac = grossAnnual * (vacancyPct / 100);
+  const maint = grossAnnual * (maintenancePct / 100);
+  const mgmt = grossAnnual * (managementPct / 100);
+  const opEx = taxes + insurance + hoa * 12 + vac + maint + mgmt + otherMonthly * 12;
+  const noi = grossAnnual - opEx;
+  const allIn = purchase + rehab;
+  const capRate = allIn > 0 ? noi / allIn : undefined;
+  const down = allIn * (downPct / 100);
+  const loanAmt = Math.max(allIn - down, 0);
+  const r = (ratePct / 100) / 12;
+  const nPmts = termYears * 12;
+  const monthlyPI = loanAmt > 0 && r > 0 && nPmts > 0 ? (loanAmt * r) / (1 - Math.pow(1 + r, -nPmts)) : 0;
+  const annualDebt = monthlyPI * 12;
+  const dscr = annualDebt > 0 ? noi / annualDebt : undefined;
+  const annualCF = noi - annualDebt;
+  const coc = (down + rehab) > 0 ? annualCF / (down + rehab) : undefined;
+  const grm = grossAnnual > 0 ? allIn / grossAnnual : undefined;
+  const grossYield = allIn > 0 ? grossAnnual / allIn : undefined;
+  const oer = grossAnnual > 0 ? opEx / grossAnnual : undefined;
+  const holdingMonths = +n.holdingMonths || +n.monthsToComplete || 0;
+  const sellingPct = (+n.sellingCostPct || 0) + (+n.closingCostPct || 0);
+  const carryOtherMonthly = +n.carryOtherMonthly || 0;
+  const carrying = (taxes / 12 + insurance / 12 + hoa + carryOtherMonthly) * holdingMonths;
+  const selling = arv * (sellingPct / 100);
+  const totalInvest = purchase + rehab + carrying + selling;
+  const profit = arv - totalInvest;
+  const margin = arv > 0 ? profit / arv : undefined;
+  const em = totalInvest > 0 ? arv / totalInvest : undefined;
+  return { capRate, dscr, annualCF, coc, grm, grossYield, oer, profit, margin, em };
+}
+
+export function renderCompareReportHTML({ deals, mode }: { deals: any[]; mode: string }) {
+  const rows = deals.map(d => ({
+    address: d.property?.address || d.title || d.id,
+    kpis: compute(d),
+  }));
+  const ranges = {
+    dscr: [Math.min(...rows.map(r => r.kpis.dscr || 0)), Math.max(...rows.map(r => r.kpis.dscr || 0))] as [number, number],
+    cap: [Math.min(...rows.map(r => r.kpis.capRate || 0)), Math.max(...rows.map(r => r.kpis.capRate || 0))] as [number, number],
+    cf: [Math.min(...rows.map(r => r.kpis.annualCF || 0)), Math.max(...rows.map(r => r.kpis.annualCF || 0))] as [number, number],
+    profit: [Math.min(...rows.map(r => r.kpis.profit || 0)), Math.max(...rows.map(r => r.kpis.profit || 0))] as [number, number],
+  };
+  const weights = { dscr: 40, cap: 30, cf: 20, profit: 10 };
+  const scored = rows.map(r => ({
+    address: r.address,
+    kpis: r.kpis,
+    score: compositeScore({ dscr: r.kpis.dscr, capRate: r.kpis.capRate, annualCF: r.kpis.annualCF, profit: r.kpis.profit }, weights, ranges),
+  }));
+
+  const headerCols = DEFAULT_KPI_COLUMNS.map(c => `<th>${c.label}</th>`).join("");
+  const bodyRows = scored
+    .map(r => {
+      const kpiCells = DEFAULT_KPI_COLUMNS.map(c => {
+        const val = (r.kpis as any)[c.key];
+        return `<td>${val !== undefined && val !== null ? (c.formatter?.(val) ?? val) : ""}</td>`;
+      }).join("");
+      return `<tr><td style="text-align:left">${r.address}</td>${kpiCells}<td>${(r.score * 100).toFixed(0)}</td></tr>`;
+    })
+    .join("");
+
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"/><title>Deal Comparison</title><style>table{width:100%;border-collapse:collapse;}th,td{border:1px solid #ddd;padding:4px;text-align:right;}th{text-align:left;}h1{font-size:20px;}</style></head><body><h1>Deal Comparison</h1><table><thead><tr><th>Property</th>${headerCols}<th>Score</th></tr></thead><tbody>${bodyRows}</tbody></table></body></html>`;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^5.13.0",
+        "@sparticuz/chromium": "^129.0.0",
         "chart.js": "^4.4.1",
         "cors": "^2.8.5",
         "framer-motion": "^10.18.0",
@@ -17,6 +18,7 @@
         "jspdf": "^3.0.2",
         "lucide-react": "^0.368.0",
         "next": "^14.1.0",
+        "puppeteer-core": "^23.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "stripe": "^12.18.0",
@@ -33,6 +35,8 @@
         "postcss": "^8.4.31",
         "prisma": "^5.13.0",
         "tailwindcss": "^3.4.1",
+        "ts-node": "^10.9.1",
+        "tsx": "^4.7.0",
         "typescript": "^5.3.3"
       }
     },
@@ -56,6 +60,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emnapi/core": {
@@ -108,6 +136,448 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+      "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+      "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+      "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+      "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+      "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+      "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+      "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+      "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+      "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+      "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+      "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+      "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+      "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+      "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+      "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+      "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+      "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+      "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+      "integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+      "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+      "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+      "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+      "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -663,6 +1133,28 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -676,6 +1168,19 @@
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sparticuz/chromium": {
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-129.0.0.tgz",
+      "integrity": "sha512-39B1OTmq0VG7QvBWDeLG+LqBclmeYLPOpjsmzb1gcC0wJwPHvbccNKcUAUH3D07cop2VCwrqmyl3zUB138ho2w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.9",
+        "tar-fs": "^3.0.6"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -692,6 +1197,40 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -749,6 +1288,16 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -1242,6 +1791,28 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1500,6 +2071,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1598,6 +2181,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.4.2.tgz",
+      "integrity": "sha512-W95NLMtnREWRbiHsMrR3mRC+Z1w80Tb3y4W2v3Sszwh+M6ll0Ss16l5Zc0LLt3FqoLYn88tqp1PipFSGlt26sA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
+      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
+      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.2.2.tgz",
+      "integrity": "sha512-g+ueNGKkrjMazDG3elZO1pNs3HY5+mMmOet1jtKyhOaCnkLzitxf26z7hoAEkDNgdNmnc1KIlt/dw6Po6xZMpA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
@@ -1605,6 +2272,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/binary-extensions": {
@@ -1674,6 +2370,39 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/busboy": {
@@ -1878,17 +2607,125 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chromium-bidi": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.11.0.tgz",
+      "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "zod": "3.23.8"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/chromium-bidi/node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1901,7 +2738,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1945,6 +2781,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1996,6 +2839,15 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2055,7 +2907,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2112,12 +2963,42 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1367902",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
+      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2196,6 +3077,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -2371,11 +3261,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+      "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.9",
+        "@esbuild/android-arm": "0.25.9",
+        "@esbuild/android-arm64": "0.25.9",
+        "@esbuild/android-x64": "0.25.9",
+        "@esbuild/darwin-arm64": "0.25.9",
+        "@esbuild/darwin-x64": "0.25.9",
+        "@esbuild/freebsd-arm64": "0.25.9",
+        "@esbuild/freebsd-x64": "0.25.9",
+        "@esbuild/linux-arm": "0.25.9",
+        "@esbuild/linux-arm64": "0.25.9",
+        "@esbuild/linux-ia32": "0.25.9",
+        "@esbuild/linux-loong64": "0.25.9",
+        "@esbuild/linux-mips64el": "0.25.9",
+        "@esbuild/linux-ppc64": "0.25.9",
+        "@esbuild/linux-riscv64": "0.25.9",
+        "@esbuild/linux-s390x": "0.25.9",
+        "@esbuild/linux-x64": "0.25.9",
+        "@esbuild/netbsd-arm64": "0.25.9",
+        "@esbuild/netbsd-x64": "0.25.9",
+        "@esbuild/openbsd-arm64": "0.25.9",
+        "@esbuild/openbsd-x64": "0.25.9",
+        "@esbuild/openharmony-arm64": "0.25.9",
+        "@esbuild/sunos-x64": "0.25.9",
+        "@esbuild/win32-arm64": "0.25.9",
+        "@esbuild/win32-ia32": "0.25.9",
+        "@esbuild/win32-x64": "0.25.9"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2392,6 +3323,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2915,6 +3867,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
@@ -2945,7 +3910,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -2955,10 +3919,29 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2966,6 +3949,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3031,6 +4020,15 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fflate": {
@@ -3103,6 +4101,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -3237,6 +4255,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3274,6 +4301,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -3303,6 +4345,20 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/glob": {
@@ -3523,6 +4579,52 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3599,6 +4701,15 @@
       "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
       "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -3788,7 +4899,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4293,6 +5403,13 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4362,11 +5479,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4421,6 +5543,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/next": {
       "version": "14.2.32",
@@ -4662,7 +5793,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4734,6 +5864,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -4825,6 +5987,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -5026,6 +6194,15 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5038,6 +6215,50 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5046,6 +6267,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "23.11.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-23.11.1.tgz",
+      "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.6.1",
+        "chromium-bidi": "0.11.0",
+        "debug": "^4.4.0",
+        "devtools-protocol": "0.0.1367902",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/qs": {
@@ -5198,6 +6436,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5417,7 +6664,6 @@
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5593,6 +6839,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5639,6 +6933,19 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string-width": {
@@ -6050,6 +7357,68 @@
         }
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
+      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar-stream/node_modules/b4a": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
+      "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-decoder/node_modules/b4a": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.1.tgz",
+      "integrity": "sha512-ZovbrBV0g6JxK5cGUF1Suby1vLfKjv4RWi8IxoaO/Mon8BDD9I21RxjHFtgQ+kskJqLAVyQZly3uMBui+vhc8Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -6088,6 +7457,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
@@ -6170,6 +7545,57 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -6188,6 +7614,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6293,6 +7739,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
@@ -6324,6 +7776,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/undici-types": {
@@ -6423,6 +7885,13 @@
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -6650,8 +8119,37 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yaml": {
       "version": "2.8.1",
@@ -6664,6 +8162,94 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node tests/propertyValuation.test.mjs",
+    "test": "node tests/propertyValuation.test.mjs && tsx tests/compare/score.test.ts",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "health": "curl -i $RENDER_API_URL/health",
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "@prisma/client": "^5.13.0",
+    "@sparticuz/chromium": "^129.0.0",
     "chart.js": "^4.4.1",
     "cors": "^2.8.5",
     "framer-motion": "^10.18.0",
@@ -26,6 +27,7 @@
     "jspdf": "^3.0.2",
     "lucide-react": "^0.368.0",
     "next": "^14.1.0",
+    "puppeteer-core": "^23.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "stripe": "^12.18.0",
@@ -42,6 +44,8 @@
     "postcss": "^8.4.31",
     "prisma": "^5.13.0",
     "tailwindcss": "^3.4.1",
+    "ts-node": "^10.9.1",
+    "tsx": "^4.7.0",
     "typescript": "^5.3.3"
   }
 }

--- a/src/components/analyzer/CalcBasesAdvanced.tsx
+++ b/src/components/analyzer/CalcBasesAdvanced.tsx
@@ -1,0 +1,96 @@
+"use client";
+import * as React from "react";
+
+type LoanBasis = "purchase" | "all_in";
+type PercentBasis = "gross" | "egi";
+type CapBasis = "purchase" | "all_in";
+type InvestedBasis = "down" | "down_plus_rehab" | "down_plus_rehab_closing";
+
+export interface Bases {
+  loanBasis: LoanBasis;
+  percentBasis: PercentBasis;
+  capBasis: CapBasis;
+  investedBasis: InvestedBasis;
+}
+
+interface Props {
+  value: Bases;
+  onChange: (b: Bases) => void;
+  className?: string;
+}
+
+const Row = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="flex items-center justify-between gap-3 py-2">
+    <div className="text-sm font-medium">{label}</div>
+    <div className="flex gap-3">{children}</div>
+  </div>
+);
+
+function Radio<T extends string>({
+  name, options, value, onChange,
+}: {
+  name: string;
+  options: { label: string; val: T }[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map(o => (
+        <label key={o.val} className="inline-flex items-center gap-1 text-sm">
+          <input type="radio" name={name} value={o.val} checked={value === o.val} onChange={() => onChange(o.val)} />
+          {o.label}
+        </label>
+      ))}
+    </div>
+  );
+}
+
+export function CalcBasesAdvanced({ value, onChange, className }: Props) {
+  return (
+    <div className={`rounded-xl border p-3 ${className ?? ""}`}>
+      <div className="text-sm font-semibold mb-2">Advanced math options</div>
+
+      <Row label="Loan basis">
+        <Radio
+          name="loanBasis"
+          options={[{ label: "Purchase", val: "purchase" }, { label: "All-In", val: "all_in" }]}
+          value={value.loanBasis}
+          onChange={(loanBasis) => onChange({ ...value, loanBasis })}
+        />
+      </Row>
+
+      <Row label="% expense basis">
+        <Radio
+          name="percentBasis"
+          options={[{ label: "Gross", val: "gross" }, { label: "EGI (Rent − Vacancy)", val: "egi" }]}
+          value={value.percentBasis}
+          onChange={(percentBasis) => onChange({ ...value, percentBasis })}
+        />
+      </Row>
+
+      <Row label="Cap/GRM basis">
+        <Radio
+          name="capBasis"
+          options={[{ label: "Purchase", val: "purchase" }, { label: "All-In", val: "all_in" }]}
+          value={value.capBasis}
+          onChange={(capBasis) => onChange({ ...value, capBasis })}
+        />
+      </Row>
+
+      <Row label="CoC invested">
+        <Radio
+          name="investedBasis"
+          options={[
+            { label: "Down", val: "down" },
+            { label: "Down + Rehab", val: "down_plus_rehab" },
+            { label: "Down + Rehab + Closing", val: "down_plus_rehab_closing" },
+          ]}
+          value={value.investedBasis}
+          onChange={(investedBasis) => onChange({ ...value, investedBasis })}
+        />
+      </Row>
+    </div>
+  );
+}
+

--- a/src/components/compare/AddToCompareButton.tsx
+++ b/src/components/compare/AddToCompareButton.tsx
@@ -1,0 +1,16 @@
+"use client";
+import { useCompareSet } from "@/lib/compare/compareStore";
+
+export function AddToCompareButton({ dealId }: { dealId: string }) {
+  const { ids, add, remove } = useCompareSet();
+  const added = ids.includes(dealId);
+  return (
+    <button
+      onClick={() => (added ? remove(dealId) : add(dealId))}
+      className={`btn ${added ? "btn-outline" : "btn-primary"}`}
+      aria-pressed={added}
+    >
+      {added ? "Remove from Compare" : "Add to Compare"}
+    </button>
+  );
+}

--- a/src/components/compare/CompareCharts.tsx
+++ b/src/components/compare/CompareCharts.tsx
@@ -1,0 +1,26 @@
+"use client";
+import * as React from "react";
+
+export function CompareCharts({ points }:{ points:{ x:number; y:number; size:number; label:string }[] }) {
+  const w = 600, h = 240, pad = 30;
+  const xs = points.map(p=>p.x), ys = points.map(p=>p.y);
+  const min = (a:number[])=>Math.min(...a), max=(a:number[])=>Math.max(...a);
+  const xMin=min(xs), xMax=max(xs), yMin=min(ys), yMax=max(ys);
+  const xScale=(v:number)=> pad + (w-2*pad) * (v-xMin)/(xMax-xMin || 1);
+  const yScale=(v:number)=> h-pad - (h-2*pad) * (v-yMin)/(yMax-yMin || 1);
+  return (
+    <div className="rounded-xl border p-3 overflow-x-auto">
+      <div className="text-sm font-medium mb-2">Cap vs DSCR (bubble size = Annual CF)</div>
+      <svg width={w} height={h}>
+        <line x1={pad} y1={h-pad} x2={w-pad} y2={h-pad} stroke="#CBD5E1"/>
+        <line x1={pad} y1={pad} x2={pad} y2={h-pad} stroke="#CBD5E1"/>
+        {points.map((p,i)=>(
+          <g key={i}>
+            <circle cx={xScale(p.x)} cy={yScale(p.y)} r={Math.max(3, Math.sqrt(Math.abs(p.size))/60)} fill="#94A3B8"/>
+            <text x={xScale(p.x)+6} y={yScale(p.y)} fontSize="10">{p.label}</text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/compare/CompareTable.tsx
+++ b/src/components/compare/CompareTable.tsx
@@ -1,0 +1,56 @@
+"use client";
+import * as React from "react";
+import type { KpiKey } from "./CompareToolbar";
+
+export interface CompareRow {
+  id: string;
+  address: string;
+  strategy: string[];
+  values: Record<KpiKey, number|undefined>;
+  score: number;
+  flags: string[];
+}
+
+export function CompareTable({ rows, kpis, onRemove }:{
+  rows: CompareRow[];
+  kpis: KpiKey[];
+  onRemove:(id:string)=>void;
+}) {
+  const fmt$ = (n:number|undefined)=> n===undefined || isNaN(n as any) ? "—" : (Math.abs(n as number)>=1000? `$${Math.round(n as number).toLocaleString()}`: `$${Math.round(n as number)}`);
+  const fmtPct = (n:number|undefined)=> n===undefined || isNaN(n as any) ? "—" : `${(n as number).toFixed(2)}%`;
+  const fmt = (key:KpiKey, v:number|undefined)=>{
+    if (key==="cap"||key==="coc"||key==="yield"||key==="oer"||key==="margin") return fmtPct((v??0)* (key==="margin"?100:100));
+    if (key==="dscr"||key==="grm"||key==="em") return v===undefined? "—" : (key==="em"? `${(v).toFixed(3)}×` : (v as number).toFixed(2));
+    return fmt$(v);
+  };
+  return (
+    <div className="rounded-xl border overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="bg-gray-50">
+            <th className="p-2 text-left">Property</th>
+            {kpis.map(k=> <th key={k} className="p-2 text-right">{k.toUpperCase()}</th>)}
+            <th className="p-2 text-right">Score</th>
+            <th className="p-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r=>(
+            <tr key={r.id} className="border-t">
+              <td className="p-2">
+                <div className="font-medium">{r.address}</div>
+                <div className="text-xs text-gray-500">{r.strategy.join(" • ")}</div>
+                {r.flags.length? <div className="text-xs text-red-600 mt-1">{r.flags.join(" | ")}</div>: null}
+              </td>
+              {kpis.map(k=> <td key={k} className="p-2 text-right">{fmt(k, r.values[k])}</td>)}
+              <td className="p-2 text-right">{(r.score*100).toFixed(0)}</td>
+              <td className="p-2 text-right">
+                <button className="text-xs underline" onClick={()=>onRemove(r.id)}>Remove</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/compare/CompareToolbar.tsx
+++ b/src/components/compare/CompareToolbar.tsx
@@ -1,0 +1,110 @@
+"use client";
+import * as React from "react";
+import { CalcPresets } from "@/lib/calc/presets";
+import type { CalcModePreset, CalcBases } from "@/lib/calc/types";
+import { CalcBasesAdvanced } from "@/components/analyzer/CalcBasesAdvanced";
+
+const KPI_CHOICES = [
+  { key: "cap", label: "Cap %" },
+  { key: "dscr", label: "DSCR" },
+  { key: "cf", label: "Annual CF" },
+  { key: "coc", label: "CoC %" },
+  { key: "grm", label: "GRM" },
+  { key: "yield", label: "Gross Yield %" },
+  { key: "oer", label: "OER %" },
+  { key: "profit", label: "Flip Profit" },
+  { key: "margin", label: "Margin %" },
+  { key: "em", label: "Equity Multiple" },
+] as const;
+
+export type KpiKey = typeof KPI_CHOICES[number]["key"];
+
+export function CompareToolbar(props: {
+  presetId: CalcModePreset["id"];
+  bases: CalcBases;
+  kpis: KpiKey[];
+  sortBy: KpiKey;
+  sortDir: "asc"|"desc";
+  filters: { dscrMin?: number; capMin?: number; cfMin?: number; profitMin?: number };
+  weights: { dscr: number; cap: number; cf: number; profit: number };
+  onPreset:(id: CalcModePreset["id"])=>void;
+  onBases:(b: CalcBases)=>void;
+  onKpis:(k: KpiKey[])=>void;
+  onSort:(key:KpiKey, dir:"asc"|"desc")=>void;
+  onFilters:(f: any)=>void;
+  onWeights:(w: any)=>void;
+  onShare:()=>void;
+  onExport:()=>void;
+  onClear:()=>void;
+}) {
+  const toggle = (k:KpiKey)=> props.onKpis(props.kpis.includes(k)? props.kpis.filter(x=>x!==k): [...props.kpis,k]);
+  return (
+    <div className="rounded-xl border p-3 grid grid-cols-1 gap-3">
+      <div className="grid md:grid-cols-3 gap-3">
+        <div>
+          <label className="text-sm font-medium">Underwriting preset</label>
+          <select className="w-full rounded border px-2 py-2 mt-1"
+            value={props.presetId}
+            onChange={(e)=>props.onPreset(e.target.value as any)}>
+            {CalcPresets.map(p=> <option key={p.id} value={p.id}>{p.id}</option>)}
+            <option value="Custom">Custom</option>
+          </select>
+          <p className="text-xs text-gray-500 mt-1">Controls loan basis, % basis, cap/GRM basis, invested basis.</p>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Sort by</label>
+          <div className="flex gap-2 mt-1">
+            <select className="rounded border px-2 py-2"
+              value={props.sortBy}
+              onChange={(e)=>props.onSort(e.target.value as any, props.sortDir)}>
+              {KPI_CHOICES.map(c=> <option key={c.key} value={c.key}>{c.label}</option>)}
+            </select>
+            <select className="rounded border px-2 py-2"
+              value={props.sortDir}
+              onChange={(e)=>props.onSort(props.sortBy, e.target.value as "asc"|"desc")}>
+              <option value="desc">Desc</option><option value="asc">Asc</option>
+            </select>
+          </div>
+        </div>
+        <div>
+          <label className="text-sm font-medium">Filters</label>
+          <div className="grid grid-cols-2 gap-2 mt-1">
+            <input className="rounded border px-2 py-1" placeholder="DSCR ≥" type="number" step="0.01"
+              value={props.filters.dscrMin ?? ""} onChange={(e)=>props.onFilters({...props.filters, dscrMin: e.target.value? +e.target.value: undefined})}/>
+            <input className="rounded border px-2 py-1" placeholder="Cap% ≥" type="number" step="0.1"
+              value={props.filters.capMin ?? ""} onChange={(e)=>props.onFilters({...props.filters, capMin: e.target.value? +e.target.value: undefined})}/>
+            <input className="rounded border px-2 py-1" placeholder="CF ≥" type="number" step="100"
+              value={props.filters.cfMin ?? ""} onChange={(e)=>props.onFilters({...props.filters, cfMin: e.target.value? +e.target.value: undefined})}/>
+            <input className="rounded border px-2 py-1" placeholder="Profit ≥" type="number" step="100"
+              value={props.filters.profitMin ?? ""} onChange={(e)=>props.onFilters({...props.filters, profitMin: e.target.value? +e.target.value: undefined})}/>
+          </div>
+        </div>
+      </div>
+
+      <details className="rounded-lg border p-3">
+        <summary className="cursor-pointer text-sm font-medium">Advanced math options</summary>
+        <div className="mt-3">
+          <CalcBasesAdvanced value={props.bases} onChange={(b)=>props.onBases(b)} />
+        </div>
+      </details>
+
+      <div>
+        <div className="text-sm font-medium">KPIs to show</div>
+        <div className="flex flex-wrap gap-3 mt-1">
+          {KPI_CHOICES.map(c=>(
+            <label key={c.key} className="inline-flex items-center gap-1 text-sm">
+              <input type="checkbox" checked={props.kpis.includes(c.key)} onChange={()=>toggle(c.key)}/>
+              {c.label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 justify-end">
+        <button className="btn btn-outline" onClick={props.onShare}>Copy share link</button>
+        <button className="btn btn-outline" onClick={props.onExport}>Export PDF</button>
+        <button className="btn" onClick={props.onClear}>Clear</button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,6 @@
+// @server-only
+// Minimal fetch helpers used by compare/analyzer pages.
+
 const BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 if (process.env.NODE_ENV !== "production" && !(process.env.NEXT_PUBLIC_API_URL ?? "")) {
@@ -19,3 +22,26 @@ export async function api(path: string, init?: RequestInit) {
   return res.json();
 }
 
+export async function fetchDeal(
+  id: string,
+  opts: { origin?: string; init?: RequestInit } = {}
+) {
+  const base =
+    opts.origin ??
+    (typeof window !== "undefined"
+      ? ""
+      : process.env.SITE_URL || "");
+  const res = await fetch(`${base}/api/deals/${id}`, {
+    cache: "no-store",
+    ...(opts.init || {}),
+  });
+  if (!res.ok) throw new Error(`fetchDeal ${id} ${res.status}`);
+  return res.json();
+}
+
+export async function fetchDeals(
+  ids: string[],
+  opts: { origin?: string; init?: RequestInit } = {}
+) {
+  return Promise.all(ids.map((id) => fetchDeal(id, opts)));
+}

--- a/tests/compare/score.test.ts
+++ b/tests/compare/score.test.ts
@@ -1,0 +1,38 @@
+import assert from "assert/strict";
+import { compositeScore, normalize } from "../../lib/compare/score";
+
+const ranges = {
+  dscr: [0, 2],
+  cap: [0, 0.1],
+  cf: [-10000, 10000],
+  profit: [-50000, 50000],
+};
+
+const weights = { dscr: 40, cap: 30, cf: 20, profit: 10 };
+
+// Score is bounded between 0 and 1
+const bounded = compositeScore(
+  { dscr: 1.2, capRate: 0.05, annualCF: 2000, profit: 10000 },
+  weights,
+  ranges
+);
+assert.ok(bounded >= 0 && bounded <= 1, "score should be within [0,1]");
+
+// Increasing DSCR increases score (monotonic)
+const scoreLow = compositeScore(
+  { dscr: 0.8, capRate: 0.05, annualCF: 2000, profit: 10000 },
+  weights,
+  ranges
+);
+const scoreHigh = compositeScore(
+  { dscr: 1.6, capRate: 0.05, annualCF: 2000, profit: 10000 },
+  weights,
+  ranges
+);
+assert.ok(scoreHigh > scoreLow, "higher dscr should yield higher score");
+
+// normalize clamps values
+assert.equal(normalize(-1, 0, 1), 0);
+assert.equal(normalize(2, 0, 1), 1);
+
+console.log("score tests passed");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,14 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "src/*",
+        "lib/*",
+        "*"
+      ]
+    },
+    "target": "es2017",
     "lib": [
       "dom",
       "dom.iterable",
@@ -12,36 +20,33 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./*"
-      ]
-    },
+    "allowJs": true,
     "plugins": [
       {
         "name": "next"
       }
-    
-    ]
+    ],
+    "strictNullChecks": true
   },
   "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "lib/**/*.ts",
+    "lib/**/*.tsx",
     ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",
     "vite.config.ts",
-    ".next",
-    "server",
-    "server/**",
-    "**/server/**"
+    "vitest.config.ts",
+    "jest.config.ts",
+    "playwright.config.ts",
+    "postcss.config.ts",
+    "tailwind.config.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- resolve calc bases UI with explicit loan, expense, cap/GRM, and invested basis selectors
- simplify TypeScript config by mapping `@/*` to `src/*` and `lib/*`
- add local API helpers for fetching deals and generic API access
- integrate compare calculations with selected bases and expose top-level `lib` in TypeScript includes

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3632cda7c8326a9cc4d9ea8cb2cef