### PR TITLE
Add calc test cases for rental and flip scenarios

### DIFF
--- a/tests/calc/flip.test.ts
+++ b/tests/calc/flip.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from 'vitest';
 import { flipKPIs } from '@/lib/calc/formulas';
 
+const TOLERANCE = 1e-2;
+const expectClose = (actual: number, expected: number) => {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(TOLERANCE);
+};
+
 test('Flip negative margin', () => {
   const d = { purchase:220000, arv:320000, rehab:60000, downPct:15, ratePct:8.5,
     holdingMonths:6, carryOtherMonthly:200, sellingCostPct:8, closingCostPct:2,
@@ -23,4 +28,35 @@ test('Flip profitable', () => {
   expect(Math.round(k.profit)).toBe(32685);
   expect(k.margin).toBeCloseTo(0.0908, 3);
   expect(k.equityMultiple).toBeCloseTo(1.320, 3);
+});
+
+test('Flip Test Case B1 returns expected profitability', () => {
+  const deal = {
+    purchase: 269400,
+    arv: 375444,
+    rehab: 30000,
+    downPct: 20,
+    ratePct: 8.5,
+    holdingMonths: 6,
+    carryOtherMonthly: 200,
+    sellingCostPct: 8,
+    closingCostPct: 2,
+    rent: 0,
+    taxes: 0,
+    insurance: 0,
+    hoaMonthly: 0,
+    otherMonthly: 0,
+    vacancyPct: 0,
+    managementPct: 0,
+    maintenancePct: 0,
+    termYears: 30
+  };
+
+  const k = flipKPIs(deal as any);
+  const cashIn = k.down + deal.rehab;
+  const roi = cashIn ? k.profit / cashIn : NaN;
+
+  expectClose(k.profit, 27120);
+  expectClose(cashIn, 89880);
+  expectClose(roi, 0.3017);
 });

--- a/tests/calc/rental.test.ts
+++ b/tests/calc/rental.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from 'vitest';
 import { rentalKPIs } from '@/lib/calc/formulas';
 import { CalcPresets } from '@/lib/calc/presets';
 
+const TOLERANCE = 1e-2;
+const expectClose = (actual: number, expected: number) => {
+  expect(Math.abs(actual - expected)).toBeLessThanOrEqual(TOLERANCE);
+};
+
 const conservative = CalcPresets.find(p => p.id === 'Conservative')!.bases;
 
 test('Rental stronger case matches expected KPIs', () => {
@@ -21,6 +26,39 @@ test('Rental stronger case matches expected KPIs', () => {
   expect(k.dscr).toBeCloseTo(1.11, 2);
   expect(Math.round(k.annualCF)).toBeCloseTo(1334, -1);
   expect(k.oer).toBeCloseTo(0.4108, 3);
+});
+
+test('Rental Test Case A aligns with baseline KPIs', () => {
+  const deal = {
+    purchase: 399700,
+    arv: 420000,
+    rehab: 15334,
+    rent: 3039.3224,
+    taxes: 7200,
+    insurance: 1000,
+    hoaMonthly: 0,
+    otherMonthly: 50,
+    vacancyPct: 5,
+    managementPct: 8,
+    maintenancePct: 5,
+    downPct: 25,
+    ratePct: 6.7573,
+    termYears: 30
+  };
+
+  const bases = {
+    loanBasis: 'purchase',
+    percentBasis: 'egi',
+    capBasis: 'purchase',
+    investedBasis: 'down_plus_rehab'
+  } as const;
+
+  const k = rentalKPIs(deal as any, bases);
+  expectClose(k.pmtMonthly, 1945.79);
+  expectClose(k.noi, 21344);
+  expectClose(k.capRate, 0.0534);
+  expectClose(k.annualCF / 12, -167.13);
+  expectClose(k.coc, -0.0174);
 });
 
 describe('DealCheck mode parity', () => {


### PR DESCRIPTION
## Summary
- add tolerance helper for KPI assertions in calc tests
- cover rental Test Case A metrics with 1e-2 tolerance checks
- add flip Test Case B1 scenario validating profit, cash in, and ROI targets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d578cb87148326b071ec409bc70bc6