### PR TITLE
feat: integrate itemized closing costs into analyzer

### DIFF
--- a/src/lib/calc/formulas.ts
+++ b/src/lib/calc/formulas.ts
@@ -69,7 +69,7 @@ export function flipKPIs(d: DealInput): FlipKPIs {
   const interestCarry = loan * (d.ratePct / 100) * ((d.holdingMonths ?? 0) / 12);
   const otherCarry = (d.carryOtherMonthly ?? 0) * (d.holdingMonths ?? 0);
   const selling = d.arv * ((d.sellingCostPct ?? 0) / 100);
-  const closing = d.arv * ((d.closingCostPct ?? 0) / 100);
+  const closing = d.closingCosts ?? d.arv * ((d.closingCostPct ?? 0) / 100);
   const totalCost = basis + interestCarry + otherCarry + selling + closing;
   const profit = d.arv - totalCost;
   const margin = d.arv ? profit / d.arv : NaN;

--- a/src/lib/calc/types.ts
+++ b/src/lib/calc/types.ts
@@ -10,7 +10,7 @@ export interface DealInput {
   vacancyPct: number; managementPct: number; maintenancePct: number;
   downPct: number; ratePct: number; termYears: number;
   holdingMonths?: number; carryOtherMonthly?: number;
-  sellingCostPct?: number; closingCostPct?: number;
+  sellingCostPct?: number; closingCostPct?: number; closingCosts?: number;
 }
 
 export interface CalcBases {


### PR DESCRIPTION
## Summary
- replace the static closing-cost input on the deal analyzer with the configurable ClosingCostsSection component
- keep the selected items in local state, surface a summary panel, and feed the computed total into downstream KPI inputs
- extend calc types and flip KPI math to accept an explicit closingCosts amount while retaining the percent fallback

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6e7685ce48326b829f06f4940dbb0