### PR TITLE
Integrate itemized closing costs into deal analyzer

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -376,6 +376,10 @@ app.get("/api/deals/:id/report", (req, res) => {
   const holdingMonths = getN("holdingMonths");
   const sellingCostPct = getN("sellingCostPct");
   const closingCostPct = getN("closingCostPct");
+  const hasClosingCostsTotal = Object.prototype.hasOwnProperty.call(n, "closingCostsTotal");
+  const hasClosingCosts = Object.prototype.hasOwnProperty.call(n, "closingCosts");
+  const closingCostsFromItemsRaw = hasClosingCostsTotal ? Number(n.closingCostsTotal) : (hasClosingCosts ? Number(n.closingCosts) : NaN);
+  const closingCostsFromItems = Number.isFinite(closingCostsFromItemsRaw) ? closingCostsFromItemsRaw : null;
   const carryOtherMonthly = getN("carryOtherMonthly");
 
   // If we’re low on space before starting Flip, force a new page
@@ -391,7 +395,7 @@ app.get("/api/deals/:id/report", (req, res) => {
     const interestCarry = loanFlip * (ratePct / 100) * (holdingMonths / 12);
     const otherCarry = (carryOtherMonthly || 0) * (holdingMonths || 0);
     const sellCosts = arv * (sellingCostPct / 100);
-    const closeCosts = arv * (closingCostPct / 100);
+    const closeCosts = closingCostsFromItems != null ? closingCostsFromItems : arv * (closingCostPct / 100);
     const totalCost = basis + interestCarry + otherCarry + sellCosts + closeCosts;
     const profit = arv - totalCost;
     const margin = arv > 0 ? (profit / arv) * 100 : NaN;
@@ -403,7 +407,8 @@ app.get("/api/deals/:id/report", (req, res) => {
     kv(`Interest Carry (${num(ratePct,2)}% APR for ${num(holdingMonths)} mo)`, $(interestCarry));
     kv("Other Carry", $(otherCarry));
     kv(`Selling Costs (${num(sellingCostPct,1)}% of ARV)`, $(sellCosts));
-    kv(`Closing Costs (${num(closingCostPct,1)}% of ARV)`, $(closeCosts));
+    const closingLabel = closingCostsFromItems != null ? "Closing Costs (itemized)" : `Closing Costs (${num(closingCostPct,1)}% of ARV)`;
+    kv(closingLabel, $(closeCosts));
     hr();
     kv("Total Cost", $(totalCost));
     kv("Profit", $(profit));

--- a/src/lib/deal/analyze.ts
+++ b/src/lib/deal/analyze.ts
@@ -32,6 +32,7 @@ export type DealInputs = {
   holdingMonthly?: HoldingMonthly;       // monthly carry during hold/rehab
   selling?: SellingBreakdown;            // Flip selling costs
   sellingCostPct?: number;               // fallback simple % of ARV (unused if breakdown present)
+  closingCosts?: number;                 // total closing costs from itemized module
 };
 
 export type DealOutputs = {
@@ -40,6 +41,7 @@ export type DealOutputs = {
   financingCost: number;     // points + interest
   holdingCost: number;       // monthly carry * months
   sellingCost: number;       // agent + itemized closing/marketing/moving
+  closingCost: number;       // purchase + exit closing total
   totalInvestment: number;   // cash in + above costs
   profit: number;            // ARV - (all-in)
   roi: number;               // profit / totalInvestment
@@ -94,11 +96,13 @@ export function analyzeFlip(inp: DealInputs): DealOutputs {
     sellingCost = salePrice * (num(inp.sellingCostPct) / 100);
   }
 
+  const closingCost = num(inp.closingCosts);
+
   // Total investment (actual cash out)
   const cashPortion = Math.max(0, pp - loanAmount) + num(inp.rehabCost);
-  const totalInvestment = cashPortion + financingCost + holdingCost + sellingCost;
+  const totalInvestment = cashPortion + financingCost + holdingCost + sellingCost + closingCost;
 
-  const profit = salePrice - (pp + num(inp.rehabCost) + financingCost + holdingCost + sellingCost);
+  const profit = salePrice - (pp + num(inp.rehabCost) + financingCost + holdingCost + sellingCost + closingCost);
   const roi = totalInvestment > 0 ? profit / totalInvestment : 0;
 
   const warnings: string[] = [];
@@ -106,7 +110,7 @@ export function analyzeFlip(inp: DealInputs): DealOutputs {
   if (inp.loan.type !== 'cash' && months > 0 && rate === 0) warnings.push('Interest rate is 0% but a financed loan is selected.');
   if (inp.loan.type === 'hard_money' && (termMonths ?? 0) > 12) warnings.push('Hard money term > 12 months is uncommon.');
 
-  return { salePrice, loanAmount, financingCost, holdingCost, sellingCost, totalInvestment, profit, roi, warnings };
+  return { salePrice, loanAmount, financingCost, holdingCost, sellingCost, closingCost, totalInvestment, profit, roi, warnings };
 }
 
 export function analyze(inputs: DealInputs): DealOutputs {


### PR DESCRIPTION
## Summary
- replace the deal analyzer closing cost input with the itemized ClosingCostsSection and persist its totals
- feed the aggregated closing costs into the client-side analyzer outputs and share workflow
- update the PDF/report generation to prefer the provided closing cost totals when available

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f6a57158832684399d2ed2809da5