### PR TITLE
Replace closing costs input with itemized section

### DIFF
--- a/src/app/tools/deal-analyzer/page.tsx
+++ b/src/app/tools/deal-analyzer/page.tsx
@@ -59,12 +59,17 @@ export default function DealAnalyzerPage() {
   const brrrr = rentalKPIs(dealInput, bases);
   const flip = flipKPIs(dealInput);
 
+  const purchasePrice = dealInput.purchase ?? 0;
+  const salePrice = dealInput.arv ?? 0;
+  const loanAmount = kpis.loanAmount;
+  const refiLoanAmount = exitMode === 'refi' ? kpis.loanAmount : undefined;
+
   const closingBases: ClosingCostBases = useMemo(() => ({
-    loan_amount: kpis.loanAmount,
-    purchase_price: dealInput.purchase,
-    sale_price: exitMode === 'sale' ? dealInput.arv : undefined,
-    refi_loan: exitMode === 'refi' ? kpis.loanAmount : undefined,
-  }), [dealInput.arv, dealInput.purchase, exitMode, kpis.loanAmount]);
+    loan_amount: loanAmount,
+    purchase_price: purchasePrice,
+    sale_price: exitMode === 'sale' ? salePrice : undefined,
+    refi_loan: exitMode === 'refi' ? refiLoanAmount : undefined,
+  }), [loanAmount, purchasePrice, salePrice, exitMode, refiLoanAmount]);
 
   const closingBreakdown = useMemo(() =>
     closingCostsItems.map(item => ({

--- a/src/components/ClosingCostsSection.tsx
+++ b/src/components/ClosingCostsSection.tsx
@@ -80,7 +80,7 @@ const HelpTip: React.FC<{ text: string }> = ({ text }) => {
         onMouseLeave={() => setOpen(false)}
         onFocus={() => setOpen(true)}
         onBlur={() => setOpen(false)}
-        onClick={() => setOpen((o) => !o)} // tap-friendly
+        onClick={() => setOpen((o) => !o)}
         className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-neutral-300 bg-white text-[10px] leading-none text-neutral-700"
         title={text}
       >
@@ -162,20 +162,17 @@ export const ClosingCostsSection: FC<ClosingCostsSectionProps> = ({
   }, [items, total, onChange]);
 
   const addItem = useCallback(() => {
-    const defaultBasis: Basis = selectableBases.includes("purchase_price")
-      ? "purchase_price"
-      : selectableBases[0] ?? "loan_amount";
     setItems((prev) => [
       ...prev,
       {
         id: uid(),
         name: "New Cost",
         type: "percent",
-        basis: defaultBasis,
+        basis: "purchase_price",
         value: 1,
       },
     ]);
-  }, [selectableBases]);
+  }, []);
 
   const removeItem = useCallback((id: string) => {
     setItems((prev) => prev.filter((i) => i.id !== id));


### PR DESCRIPTION
## Summary
- wire the deal analyzer to use the itemized ClosingCostsSection component and feed it derived basis values from the form
- route analyzer math and display logic through the computed closing cost total from the section
- update the ClosingCostsSection helper tooltip to support hover/focus/tap and default new rows to percent of purchase price

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da02aec8d08326809110852105b648